### PR TITLE
added to the date format section to explicitly state preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Alright…let’s get into it.
 - **Dates in region-specific formats.** Americans put the month first
   ("06-02-2012" for June 2nd, 2012, which makes *no* sense), while Brits
   use a robotic-looking "2 June 2012", yet pronounce it "June 2nd, 2012".
+  Regardless of where you're from, the meaning of "June 2nd, 2012" is clear
+  and unambiguous, and thus is the recommended date format for your change log.
 
 There’s more. Help me collect those unicorn tears by
 [opening an issue](https://github.com/olivierlacan/keep-a-changelog/issues/new)


### PR DESCRIPTION
The date section suggested that region specific formats were bad, but never clearly stated what the suggested format was. This has been corrected.
