### PR TITLE
Add ISO date note, and link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Added
+- Link, and make it obvious that date format is ISO 8601
 ### Fixed
 - Fix Markdown links to tag comparison URL with footnote-style links.
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ Alright…let’s get into it.
 - **Dates in region-specific formats.** Americans put the month first
   ("06-02-2012" for June 2nd, 2012, which makes *no* sense), while Brits
   use a robotic-looking "2 June 2012", yet pronounce it differently.
-  "2014-06-02" works logically from largest to smallest, and doesn't overlap
-  in ambiguous ways with other date formats, and thus is the recommended
-  date format for change logs.
+  "2014-06-02" works logically from largest to smallest, doesn't overlap in
+  ambiguous ways with other date formats, and is an
+  [ISO standard](http://www.iso.org/iso/home/standards/iso8601.htm). Thus, it
+  is the recommended date format for change logs.
 
 There’s more. Help me collect those unicorn tears by
 [opening an issue](https://github.com/olivierlacan/keep-a-changelog/issues/new)

--- a/index.html
+++ b/index.html
@@ -89,9 +89,10 @@ another, it should be painfully clear when something will break.</li>
 <li><strong>Dates in region-specific formats.</strong> Americans put the month first
 (&quot;06-02-2012&quot; for June 2nd, 2012, which makes <em>no</em> sense), while Brits
 use a robotic-looking &quot;2 June 2012&quot;, yet pronounce it differently.
-&quot;2014-06-02&quot; works logically from largest to smallest, and doesn&#39;t overlap
-in ambiguous ways with other date formats, and thus is the recommended
-date format for change logs.</li>
+&quot;2014-06-02&quot; works logically from largest to smallest, doesn&#39;t overlap in
+ambiguous ways with other date formats, and is an
+<a href="http://www.iso.org/iso/home/standards/iso8601.htm">ISO standard</a>. Thus, it
+is the recommended date format for change logs.</li>
 </ul>
 <p>There’s more. Help me collect those unicorn tears by
 <a href="https://github.com/olivierlacan/keep-a-changelog/issues/new">opening an issue</a>


### PR DESCRIPTION
To provide more info on the date format, and make it blatantly obvious that the YYYY-MM-DD format is a _standard_, provide a link to the ISO8601 reference page.