### PR TITLE
Give some reasoning against using commit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,16 @@ Some projects also use `HISTORY.txt`, `HISTORY.md`, `History.md`, `NEWS.txt`,
 It’s a mess. All these names only makes it harder for people to find it.
 
 ### Why can’t people just use a `git log` diff?
-Because log diffs are full of noise. Can we really expect every single
-commit in an open source project to be meaningful and self-explanatory?
-That seems like a pipe dream.
+Because log diffs are full of noise — by nature. They could not make a suitable
+change log even in a hypothetical project run by perfect humans who never make
+typos, never forget to commit new files, never miss any part of a refactoring.
+The purpose of a commit is to document one atomic step in the process by which
+the code evolves from one state to another. The purpose of a change log is to
+document the noteworthy differences between these states.
+
+As is the difference between good comments and the code itself,
+so is the difference between a change log and the commit log:
+one describes the *why*, the other the how.
 
 ### Can change logs be automatically parsed?
 It’s difficult, because people follow wildly different formats and file names.


### PR DESCRIPTION
“That seems like a pipe dream” is not an argument. A lot of things “seem like a pipe dream” to someone or other. That doesn’t mean they cannot be done, nor, more importantly, is it any sort of reason, in and of itself, that they *oughtn’t*.

But there *is* a strong case that can be be made against commit logs as change logs. The section just fails to make it.

This patch adds that.

(I don’t do much with Ruby so I don’t have a meaningful Ruby installation on this machine, and I couldn’t be bothered to set up the toolchain to do the regeneration stuff. So I’m afraid you’ll have to amend the commit before you merge it. Sorry about that.)