### PR TITLE
Add automatically generated change log file.

### DIFF
--- a/CHANGELOG_AUTO.md
+++ b/CHANGELOG_AUTO.md
@@ -1,0 +1,139 @@
+# Change Log
+
+## [Unreleased](https://github.com/olivierlacan/keep-a-changelog/tree/HEAD)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...HEAD)
+
+**Closed issues:**
+
+- Separate changelogs for different branches [\#62](https://github.com/olivierlacan/keep-a-changelog/issues/62)
+
+**Merged pull requests:**
+
+- Give some reasoning against using commit logs [\#61](https://github.com/olivierlacan/keep-a-changelog/pull/61) ([ap](https://github.com/ap))
+
+## [v0.0.8](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.8) (2015-02-17)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8)
+
+**Closed issues:**
+
+- Minor corrections [\#55](https://github.com/olivierlacan/keep-a-changelog/issues/55)
+
+**Merged pull requests:**
+
+- Update year to match in every example [\#52](https://github.com/olivierlacan/keep-a-changelog/pull/52) ([corvannoorloos](https://github.com/corvannoorloos))
+
+- Update year to match in every example [\#42](https://github.com/olivierlacan/keep-a-changelog/pull/42) ([corvannoorloos](https://github.com/corvannoorloos))
+
+## [v0.0.7](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.7) (2015-02-16)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7)
+
+**Closed issues:**
+
+- Change log does not mention whether the project follows Semantic Versioning [\#47](https://github.com/olivierlacan/keep-a-changelog/issues/47)
+
+- Dealing with yanked versions [\#35](https://github.com/olivierlacan/keep-a-changelog/issues/35)
+
+- Question: what about entries that are focused on performance? [\#24](https://github.com/olivierlacan/keep-a-changelog/issues/24)
+
+- Date pronunciation by Brits [\#23](https://github.com/olivierlacan/keep-a-changelog/issues/23)
+
+- The First-Look CHANGELOG doesn't include an Unreleased section [\#21](https://github.com/olivierlacan/keep-a-changelog/issues/21)
+
+**Merged pull requests:**
+
+- Add ISO date note, and link [\#50](https://github.com/olivierlacan/keep-a-changelog/pull/50) ([RickyCook](https://github.com/RickyCook))
+
+- Add note about adhering to SemVer [\#48](https://github.com/olivierlacan/keep-a-changelog/pull/48) ([ravage84](https://github.com/ravage84))
+
+- fix `unreleased` link [\#45](https://github.com/olivierlacan/keep-a-changelog/pull/45) ([ngoldman](https://github.com/ngoldman))
+
+## [v0.0.6](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.6) (2014-12-13)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6)
+
+**Closed issues:**
+
+- No "changed" group mentioned.  [\#37](https://github.com/olivierlacan/keep-a-changelog/issues/37)
+
+- The "Change" section. [\#20](https://github.com/olivierlacan/keep-a-changelog/issues/20)
+
+**Merged pull requests:**
+
+- Fix: Added "Changed" \#37 [\#39](https://github.com/olivierlacan/keep-a-changelog/pull/39) ([gintsmurans](https://github.com/gintsmurans))
+
+- Added a Changed group to the list of groups. [\#36](https://github.com/olivierlacan/keep-a-changelog/pull/36) ([cstanhope](https://github.com/cstanhope))
+
+- Use GitHub Pages \(Jekyll\) to auto-build http://keepachangelog.com [\#26](https://github.com/olivierlacan/keep-a-changelog/pull/26) ([Zearin](https://github.com/Zearin))
+
+- Use smart quotes in README.md \(for non-code\) [\#25](https://github.com/olivierlacan/keep-a-changelog/pull/25) ([Zearin](https://github.com/Zearin))
+
+## [v0.0.5](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.5) (2014-12-13)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5)
+
+**Closed issues:**
+
+- ambiguity in "guidelines for contributing" [\#32](https://github.com/olivierlacan/keep-a-changelog/issues/32)
+
+- Use underlines rather than "\#\#" for entries [\#19](https://github.com/olivierlacan/keep-a-changelog/issues/19)
+
+**Merged pull requests:**
+
+- Link to XKCD for date format argumentation [\#40](https://github.com/olivierlacan/keep-a-changelog/pull/40) ([hannesvdvreken](https://github.com/hannesvdvreken))
+
+- added to the date format section to explicitly state prefernce [\#31](https://github.com/olivierlacan/keep-a-changelog/pull/31) ([masukomi](https://github.com/masukomi))
+
+- added to the date format section to explicitly state preference [\#29](https://github.com/olivierlacan/keep-a-changelog/pull/29) ([masukomi](https://github.com/masukomi))
+
+- Distort example image [\#18](https://github.com/olivierlacan/keep-a-changelog/pull/18) ([Zearin](https://github.com/Zearin))
+
+## [v0.0.4](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.4) (2014-09-01)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4)
+
+**Merged pull requests:**
+
+- Readme tweaks [\#17](https://github.com/olivierlacan/keep-a-changelog/pull/17) ([Zearin](https://github.com/Zearin))
+
+- Readme tweaks [\#16](https://github.com/olivierlacan/keep-a-changelog/pull/16) ([Zearin](https://github.com/Zearin))
+
+- Various README updates [\#13](https://github.com/olivierlacan/keep-a-changelog/pull/13) ([Zearin](https://github.com/Zearin))
+
+- Propose way to minimize the effort required [\#12](https://github.com/olivierlacan/keep-a-changelog/pull/12) ([nathanl](https://github.com/nathanl))
+
+- Make index.html markup more human-friendly [\#11](https://github.com/olivierlacan/keep-a-changelog/pull/11) ([Zearin](https://github.com/Zearin))
+
+- Use smart quotes in README.md [\#10](https://github.com/olivierlacan/keep-a-changelog/pull/10) ([Zearin](https://github.com/Zearin))
+
+- Fix British date format example [\#9](https://github.com/olivierlacan/keep-a-changelog/pull/9) ([ravinggenius](https://github.com/ravinggenius))
+
+## [v0.0.3](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.3) (2014-08-09)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3)
+
+**Merged pull requests:**
+
+- show comparative UK date format in example [\#5](https://github.com/olivierlacan/keep-a-changelog/pull/5) ([the-undefined](https://github.com/the-undefined))
+
+## [v0.0.2](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.2) (2014-07-11)
+
+[Full Changelog](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2)
+
+**Closed issues:**
+
+- Chronological Order? [\#6](https://github.com/olivierlacan/keep-a-changelog/issues/6)
+
+**Merged pull requests:**
+
+- Propose alternatives to Markdown [\#4](https://github.com/olivierlacan/keep-a-changelog/pull/4) ([wallyqs](https://github.com/wallyqs))
+
+- fix spelling mistake [\#3](https://github.com/olivierlacan/keep-a-changelog/pull/3) ([adamvduke](https://github.com/adamvduke))
+
+## [v0.0.1](https://github.com/olivierlacan/keep-a-changelog/tree/v0.0.1) (2014-05-31)
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*


### PR DESCRIPTION
Hi, as I can see, you are carefully fill tags and labels for issues in your repo.

And special for such cases - I created a [github_changelog_generator](https://github.com/skywinder/github-changelog-generator), that generate change log file based on **tags**, **issues** and merged **pull requests** (and split them to separate lists according labels) from :octocat: GitHub Issue Tracker.

By using this script your Change Log will look like this: [Change Log](https://github.com/skywinder/keep-a-changelog/blob/add-change-log-file/CHANGELOG_AUTO.md)

And now you don't need to spend a lot of :hourglass_flowing_sand: for filling it manually!

Some essential features of **github_changelog_generator**:

- Generate **neat** Change Log file according basic [change log guidelines](http://keepachangelog.com). :gem:

- **Distinguish** issues **according labels**:
    - Merged pull requests (all `merged` pull-requests)
    - Bug fixes (by label `bug` in issue)
    - Enhancements (by label `enhancement` in issue)
    - 	Issues (closed issues `w/o any labels`)

-  it **exclude** not-related to changelog issues (any issue, that has label `question` `duplicate` `invalid` `wontfix` )  :scissors:

- You can set which labels should be included/excluded and apply a lot of other customisations, to fit changelog for your personal style :tophat: (*look `github_changelog_generator --help`  for details)*

You can easily update this file in future by simply run script: `github_changelog_generator #{options[:repo]}` in your repo folder and it make your Change Log file up-to-date again!

Since now you don't have to fill your `CHANGELOG.md` manually: just run script, relax and take a cup of :coffee: before your next release!

Hope you find this commit as useful. :wink: