### PR TITLE
remove unnecessary extra [unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased][unreleased]
+## [Unreleased]
 ### Changed
 - Improve argument against commit logs.
 
@@ -68,7 +68,7 @@ notable changes.
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
 
-[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...HEAD
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...HEAD
 [0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
 [0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
 [0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6


### PR DESCRIPTION
It's totally unnecessary to use `[Unreleased][unreleased]` link notation. I would argue that

```md
## [Unreleased]

[Unreleased]: http://...
```

is much cleaner than

```md
## [Unreleased][unreleased]

[unreleased]: http://...
```

and more consistent with the rest of the link references.

> from discussion at https://github.com/Esri/resource-proxy/pull/275#discussion_r37324456

:grin: 