### PR TITLE
Changes "why" to "what" in document

### DIFF
--- a/source/de/index.haml
+++ b/source/de/index.haml
@@ -110,7 +110,7 @@ language: de
 
   Der Unterschied zwischen dem Changelog und dem Commit-Log ist wie der Unterschied
   zwischen guten Kommentaren und dem Code selbst:
-  Das eine beschreibt das *wieso*, das andere das *wie*.
+  Das eine beschreibt das *was*, das andere das *wie*.
 
   ### Kann man Changelogs automatisiert parsen?
   Es ist nicht einfach, weil äusserst unterschiedliche Formate und Dateinamen verwendet

--- a/source/index.haml
+++ b/source/index.haml
@@ -112,7 +112,7 @@ language: en
 
   As is the difference between good comments and the code itself,
   so is the difference between a change log and the commit log:
-  one describes the *why*, the other the how.
+  one describes the *what*, the other the how.
 
   ### Can change logs be automatically parsed?
   It’s difficult, because people follow wildly different formats and file names.


### PR DESCRIPTION
I think it makes more sense to use "what" here instead of "why", because
from you definition:

>   A change log is a file which contains a curated, chronologically
>   ordered list of notable changes for each version of a project.

So it should contain what changed, and not why it did.
