### PR TITLE
Add link back to keepachangelog.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
-The format conforms to [keepachangelog.com](http://keepachangelog.com/).
+The format conforms to [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
-The format conforms to [Keep a Changelog](http://keepachangelog.com/).
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
+The format conforms to [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
 ### Added


### PR DESCRIPTION
Usually every time I'm adding entries to the changelog, I forget the format. I then open the browser and come back to the website to refresh my memory. This is fine, but contributors to the project might not know that the `CHANGELOG.md` follows a specific format, and add headings with different, non-conforming names.

Making it clear what the format is for the CHANGELOG should help level set any contributors.

I ❤️ this project so much! We use this format extensively.