### PR TITLE
Add charset config to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ root = true
 # use the same settings everywhere
 [*]
 end_of_line = lf
+charset = utf-8
 insert_final_newline = true
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
There are several translations in `source/` directory, so I think this config makes things a bit better!