### PR TITLE
Subheadings for added/changed/etc are optional

### DIFF
--- a/source/en/0.3.0/index.html.haml
+++ b/source/en/0.3.0/index.html.haml
@@ -53,6 +53,7 @@ version: 0.3.0
       - `Removed` for deprecated features removed in this release.
       - `Fixed` for any bug fixes.
       - `Security` to invite users to upgrade in case of vulnerabilities.
+    - If your change log is small enough, the sub-headings might not make sense. Use common sense. English also works to explain whether things are added, changed, etc.
 
   ### How can I minimize the effort required?
   Always have an `"Unreleased"` section at the top for keeping track of any


### PR DESCRIPTION
For change logs without many changes (for example, one change per release), the sub-headings are overkill.
