### PR TITLE
Move links right before headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...HEAD
 ## [Unreleased]
 ### Added
 - zh-CN and zh-TW translations from @tianshuo.
@@ -18,18 +19,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 translation authors keep things up-to-date.
 - Fix typos in zh-CN translation.
 - Fix typos in pt-BR translation.
+- Links right before headings.
 
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
 ## [0.3.0] - 2015-12-03
 ### Added
 - RU translation from @aishek.
 - pt-BR translation from @tallesl.
 - es-ES translation from @ZeliosAriex.
 
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
 ## [0.2.0] - 2015-10-06
 ### Changed
 - Remove exclusionary mentions of "open source" since this project can benefit
 both "open" and "closed" source projects equally.
 
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
 ## [0.1.0] - 2015-10-06
 ### Added
 - Answer "Should you ever rewrite a change log?".
@@ -38,6 +43,7 @@ both "open" and "closed" source projects equally.
 - Improve argument against commit logs.
 - Start following [SemVer](http://semver.org) properly.
 
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
 ## [0.0.8] - 2015-02-17
 ### Changed
 - Update year to match in every README example.
@@ -48,6 +54,7 @@ both "open" and "closed" source projects equally.
 - Fix typos in recent README changes.
 - Update outdated unreleased diff link.
 
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
 ## [0.0.7] - 2015-02-16
 ### Added
 - Link, and make it obvious that date format is ISO 8601.
@@ -58,16 +65,19 @@ both "open" and "closed" source projects equally.
 ### Fixed
 - Fix Markdown links to tag comparison URL with footnote-style links.
 
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
 ## [0.0.6] - 2014-12-12
 ### Added
 - README section on "yanked" releases.
 
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
 ## [0.0.5] - 2014-08-09
 ### Added
 - Markdown links to version tags on release headings.
 - Unreleased section to gather unreleased changes and encourage note
 keeping prior to releases.
 
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
 ## [0.0.4] - 2014-08-09
 ### Added
 - Better explanation of the difference between the file ("CHANGELOG")
@@ -84,10 +94,12 @@ create too much noise in the file. People will have to assume that the
 missing sections were intentionally left out because they contained no
 notable changes.
 
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
 ## [0.0.3] - 2014-08-09
 ### Added
 - "Why should I care?" section mentioning The Changelog podcast.
 
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
 ## [0.0.2] - 2014-07-10
 ### Added
 - Explanation of the recommended reverse chronological release ordering.
@@ -99,15 +111,3 @@ notable changes.
 - README now contains answers to common questions about CHANGELOGs
 - Good examples and basic guidelines, including proper date formatting.
 - Counter-examples: "What makes unicorns cry?"
-
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
-[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
-[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
-[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
-[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
-[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
-[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
-[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2


### PR DESCRIPTION
Helpful for avoid scrolling in large CHANGELOGs.