### PR TITLE
Pin format spec major versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 


### PR DESCRIPTION
You can only comply with a specification if you know it. Since new versions are released without users knowing it immediately the only valid option is to pin the specification version which you know you comply with.

Ref: https://github.com/olivierlacan/keep-a-changelog/issues/103
Used by: https://github.com/debops/
