### PR TITLE
Improve Spanish translation

### DIFF
--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -33,21 +33,26 @@ version: 1.0.0
     ¿Qué es un registro de cambios (changelog)?
 
   %p
-    Un registro de cambios, «changelog» de ahora en adelante, es un archivo que contiene una lista cronológicamente ordenada de los cambios más destacables para cada versión de un proyecto.
+    Un registro de cambios, «changelog» de ahora en adelante, es un archivo que
+contiene una lista cronológicamente ordenada de los cambios más destacables
+para cada versión de un proyecto.
 
   %h3#why
     %a.anchor{ href: "#why", aria_hidden: "true" }
     ¿Por qué mantener un changelog?
 
   %p
-    Para facilitar a los usuarios y colaboradores ver exactamente qué cambios reseñables se han realizados entre cada versión del proyecto.
+    Para facilitar a los usuarios y colaboradores ver exactamente qué cambios
+reseñables se han realizados entre cada versión del proyecto.
 
   %h3#who
     %a.anchor{ href: "#who", aria_hidden: "true" }
     ¿Quién necesita un changelog?
 
   %p
-    Las personas. Ya sean consumidores o desarrolladores, los usuarios finales del software son seres humanos a los que le importa lo que hay en el software. Cuando el software cambia, la gente quiere saber el porqué y el cómo.
+    Las personas. Ya sean consumidores o desarrolladores, los usuarios finales
+del software son seres humanos a los que le importa lo que hay en el software.
+Cuando el software cambia, la gente quiere saber el porqué y el cómo.
 
 .good-practices
   %h3#how
@@ -86,7 +91,8 @@ version: 1.0.0
       para los cambios en las funcionalidades existentes.
     %li
       %code Deprecated
-      para indicar que una característica o funcionalidad está obsoleta y que se eliminará en las próximas versiones.
+      para indicar que una característica o funcionalidad está obsoleta y que
+se eliminará en las próximas versiones.
     %li
       %code Removed
       para las características en desuso que se eliminaron en esta versión.
@@ -104,7 +110,8 @@ version: 1.0.0
     ¿Cómo puedo minimizar el esfuerzo requerido para mantener el changelog?
 
   %p
-    Mantén una sección con el nombre <code>Unreleased</code> para hacer un seguimiento sobre los próximos cambios.
+    Mantén una sección con el nombre <code>Unreleased</code> para hacer un
+seguimiento sobre los próximos cambios.
 
   %p Esto nos puede servir para dos cosas:
 
@@ -112,7 +119,8 @@ version: 1.0.0
     %li
       La gente puede ver qué cambios podrían esperar en los próximos lanzamientos.
     %li
-      Al lanzar una nueva versión, tan sólo habría que mover el contenido de <code>Unreleased</code> a una sección para la nueva versión.
+      Al lanzar una nueva versión, tan sólo habría que mover el contenido de
+<code>Unreleased</code> a una sección para la nueva versión.
 
 .bad-practices
   %h3#bad-practices
@@ -126,29 +134,44 @@ version: 1.0.0
     Usar un diff de los logs de los commits
 
   %p
-    Usar un diff de los logs de los commits es una mala idea: están llenos de ruido. Cosas como hacer <em>merge</em> de los commits, commits con títulos poco claros, cambios de documentación, etc.
+    Usar un diff de los logs de los commits es una mala idea: están llenos de
+ruido. Cosas como hacer <em>merge</em> de los commits, commits con títulos poco
+claros, cambios de documentación, etc.
 
   %p
-    El propósito de un commit es documentar un paso en la evolución del código fuente. Algunos proyectos limpian los commits, otros no.
+    El propósito de un commit es documentar un paso en la evolución del código
+fuente. Algunos proyectos limpian los commits, otros no.
 
   %p
-    El propósito de una entrada en el changelog es documentar cambios notables, usualmente entre múltiples commits, para comunicarlos claramente a los usuarios finales.
+    El propósito de una entrada en el changelog es documentar cambios notables,
+usualmente entre múltiples commits, para comunicarlos claramente a los usuarios
+finales.
 
   %h4#ignoring-deprecations
     %a.anchor{ href: "#ignoring-deprecations", aria_hidden: "true" }
     Ignorar <em>funcionalidades sin soporte</em>
 
   %p
-    Cuando la gente actualiza de una version a otra, debería estar bastante claro cuándo algo se va a romper. Debería ser posible actualizar a una versión que detalle funcionalidades sin soporte, eliminar lo que está obsoleto y actualizar a la versión donde esas funcionalidades han sido eliminadas.
+    Cuando la gente actualiza de una version a otra, debería estar bastante
+claro cuándo algo se va a romper. Debería ser posible actualizar a una versión
+que detalle funcionalidades sin soporte, eliminar lo que está obsoleto y
+actualizar a la versión donde esas funcionalidades han sido eliminadas.
   %p
-    Si no haces nada más, enumera lo que queda obsoleto, lo eliminado y cualquier otro cambio sin compatibilidad hacia atrás en tu changelog.
+    Si no haces nada más, enumera lo que queda obsoleto, lo eliminado y
+cualquier otro cambio sin compatibilidad hacia atrás en tu changelog.
 
   %h4#confusing-dates
     %a.anchor{ href: "#confusing-dates", aria_hidden: "true" }
     Fechas confusas
 
   %p
-    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code> aunque lo proununcien diferente. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha y es un #{link_to "Estándar ISO", iso}. Por lo cual, es el formato de fecha recomendado para el changelog.
+    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para
+el 2 de junio del 2012), mientras que muchas personas en el resto del mundo
+escriben de una manera muy robótica <code>2 Junio 2012</code> aunque lo
+proununcien diferente. <code>2012-06-02</code> funciona logicamente desde el
+más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos
+de fecha y es un #{link_to "Estándar ISO", iso}. Por lo cual, es el formato de
+fecha recomendado para el changelog.
 
   %aside
     Hay más. Ayúdame a recoger estos anti-patrones
@@ -165,12 +188,15 @@ version: 1.0.0
     ¿Hay un formato estándar para el changelog?
 
   %p
-    No. Hay una guía de estilo del GNU o los dos parrafos del archivo <code>guideline</code> del <em>GNU NEWS</em>. Ambos son inadecuados o insuficientes.
+    No. Hay una guía de estilo del GNU o los dos parrafos del archivo
+<code>guideline</code> del <em>GNU NEWS</em>. Ambos son inadecuados o
+insuficientes.
 
   %p
     Este proyecto apunta a ser
     = link_to "una mejor convención de changelog.", changelog
-    Esto se da observando las buenas prácticas en la comunidad open source y recopilando las mismas.
+    Esto se da observando las buenas prácticas en la comunidad open source y
+recopilando las mismas.
 
   %p
     Críticas saludables, discusión y sugerencias para mejoras
@@ -186,31 +212,46 @@ version: 1.0.0
     <code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
 
   %p
-    Si bien es fácil pensar que el nombre de tu archivo de changelog no importa tanto, ¿Por qué hacer difícil para los usuarios finales conseguir de manera consistente los cambios notables?
+    Si bien es fácil pensar que el nombre de tu archivo de changelog no importa
+tanto, ¿Por qué hacer difícil para los usuarios finales conseguir de manera
+consistente los cambios notables?
 
   %h4#github-releases
     %a.anchor{ href: "#github-releases", aria_hidden: "true" }
     ¿Y qué hay de los releases de Github?
 
   %p
-    Es una gran iniciativa. #{link_to "Los releases de Github", ghr} pueden ser utilizados para convertir simples etiquetas de git (por ejemplo una etiqueta llamada <code>v1.0.0</code>) en ricas notas de lanzamiento ya sea añadiendo estas manualmente o trayendo los mensajes anotados de las etiquetas de git y convertirlas en notas.
+    Es una gran iniciativa. #{link_to "Los releases de Github", ghr} pueden ser
+utilizados para convertir simples etiquetas de git (por ejemplo una etiqueta
+llamada <code>v1.0.0</code>) en ricas notas de lanzamiento ya sea añadiendo
+estas manualmente o trayendo los mensajes anotados de las etiquetas de git y
+convertirlas en notas.
 
   %p
-    Los releases de Github crean un changelog no portable que sólo pueden ser mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan muy parecidas al formato de <em>Mantenga un changelog</em>, pero tiende a ser un poco más complicado.
+    Los releases de Github crean un changelog no portable que sólo pueden ser
+mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan
+muy parecidas al formato de <em>Mantenga un changelog</em>, pero tiende a ser
+un poco más complicado.
 
   %p
-    La versión actual de los releases de Github es también discutiblemente no muy detectable por los usuarios finales, diferente a los típicos archivos en mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, etc.). Otro problema menor es que la interfaz actualmente no ofrece enlaces a los registros de los commits entre cada lanzamiento.
+    La versión actual de los releases de Github es también discutiblemente no
+muy detectable por los usuarios finales, diferente a los típicos archivos en
+mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, etc.). Otro
+problema menor es que la interfaz actualmente no ofrece enlaces a los registros
+de los commits entre cada lanzamiento.
 
   %h4#automatic
     %a.anchor{ href: "#automatic", aria_hidden: "true" }
     ¿Se pueden analizar gramaticalmente los changelogs?
 
   %p
-    Es difícil, porque las personas usan formatos y nombres de archivos muy distintos.
+    Es difícil, porque las personas usan formatos y nombres de archivos muy
+distintos.
 
   %p
-    #{link_to "Vandamme", vandamme} es una gema de Ruby creada por el equipo de 
-    #{link_to "Gemnasium", gemnasium} que analiza gramaticalmente muchos (pero no todos) los changelogs de proyectos open source.
+    #{link_to "Vandamme", vandamme} es una gema de Ruby creada por el equipo de
+#{link_to "Gemnasium", gemnasium} que analiza gramaticalmente muchos (pero no
+todos) los changelogs de proyectos open source.
 
 
   %h4#yanked
@@ -218,12 +259,16 @@ version: 1.0.0
     ¿Qué hay sobre las versiones retiradas?
 
   %p
-    «Yanked releases» son versiones que tuvieron que ser retiradas por un error grave o problema de seguridad. Con frecuencia estas versiones ni siquiera aparecen en los changelogs. Deberían. Así es como deberían mostrarse:
+    «Yanked releases» son versiones que tuvieron que ser retiradas por un error
+grave o problema de seguridad. Con frecuencia estas versiones ni siquiera
+aparecen en los changelogs. Deberían. Así es como deberían mostrarse:
 
   %p <code>## 0.0.5 - 2014-12-13 [YANKED]</code>
 
   %p
-    La etiqueta <code>[YANKED]</code> está destacada por una razón: es importante que destaque. El hecho de estar entre corchetes la hace también más fácil de localizar programáticamente.
+    La etiqueta <code>[YANKED]</code> está destacada por una razón: es
+importante que destaque. El hecho de estar entre corchetes la hace también más
+fácil de localizar programáticamente.
 
 
   %h4#rewrite
@@ -231,10 +276,14 @@ version: 1.0.0
     ¿Deberías volver a escribir un changelog?
 
   %p
-    Por supuesto. Siempre hay buenas razones para mejorar el changelog. A veces abro «pull requests» para añadir registros faltantes en el changelog de proyectos open source.
+    Por supuesto. Siempre hay buenas razones para mejorar el changelog. A veces
+abro «pull requests» para añadir registros faltantes en el changelog de
+proyectos open source.
 
   %p
-    También es posible que puedas descubrir que olvidaste señalar un cambio sin compatibilidad hacia atrás en las notas para una versión. En este caso es importante para ti actualizar el changelog.
+    También es posible que puedas descubrir que olvidaste señalar un cambio sin
+compatibilidad hacia atrás en las notas para una versión. En este caso es
+importante para ti actualizar el changelog.
 
 
   %h4#contribute
@@ -242,10 +291,12 @@ version: 1.0.0
     ¿Cómo puedo contribuir?
 
   %p
-    Este documento no es la <strong>verdad absoluta</strong>; es mi cuidadosa opinión, junto con información y ejemplos que recopilé.
+    Este documento no es la <strong>verdad absoluta</strong>; es mi cuidadosa
+opinión, junto con información y ejemplos que recopilé.
 
   %p
-    Esto es porque quiero que la comunidad llegue a un consenso. Creo que la discusión es tan importante como el resultado final.
+    Esto es porque quiero que la comunidad llegue a un consenso. Creo que la
+discusión es tan importante como el resultado final.
 
   %p
     Así que por favor <strong>#{link_to "comienza a colaborar", gh}</strong>.
@@ -253,4 +304,6 @@ version: 1.0.0
 .press
   %h3 Conversaciones
   %p
-    Fui a #{link_to "The Changelog podcast", thechangelog} para hablar acerca del porqué los mantenedores y colaboradores deberían preocuparse por los changelogs, y también acerca de las motivaciones detrás de este proyecto.
+    Fui a #{link_to "The Changelog podcast", thechangelog} para hablar acerca
+del porqué los mantenedores y colaboradores deberían preocuparse por los
+changelogs, y también acerca de las motivaciones detrás de este proyecto.

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -165,13 +165,15 @@ cualquier otro cambio sin compatibilidad hacia atrás en tu changelog.
     Fechas confusas
 
   %p
-    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para
-el 2 de junio del 2012), mientras que muchas personas en el resto del mundo
-escriben de una manera muy robótica <code>2 Junio 2012</code> aunque lo
-proununcien diferente. <code>2012-06-02</code> funciona logicamente desde el
-más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos
-de fecha y es un #{link_to "Estándar ISO", iso}. Por lo cual, es el formato de
-fecha recomendado para el changelog.
+    Los formatos de fecha regionales varían en todo el mundo y con
+frecuencia es difícil encontrar un formato intuitivo para todos. La
+ventaja de las fechas con el formato <code>2017-07-17</code> es que
+siguen un orden de unidades de mayor a menor: año, mes y día. Este
+formato tampoco coincide de forma ambigua con otros formatos de fecha,
+a diferencia de algunos que intercambian la posición del mes y el día.
+Todo esto, junto al hecho de ser un #{link_to "estándar ISO", iso}, son
+los motivos por los que es el formato de fecha recomendado para las
+entradas del changelog.
 
   %aside
     Hay más. Ayúdame a recoger estos anti-patrones

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -34,8 +34,8 @@ version: 1.0.0
 
   %p
     Un registro de cambios, «changelog» de ahora en adelante, es un archivo que
-contiene una lista cronológicamente ordenada de los cambios más destacables
-para cada versión de un proyecto.
+contiene una lista cronológicamente ordenada de los cambios más destacables para
+cada versión de un proyecto.
 
   %h3#why
     %a.anchor{ href: "#why", aria_hidden: "true" }
@@ -91,8 +91,8 @@ Cuando el software cambia, la gente quiere saber el porqué y el cómo.
       para los cambios en las funcionalidades existentes.
     %li
       %code Deprecated
-      para indicar que una característica o funcionalidad está obsoleta y que
-se eliminará en las próximas versiones.
+      para indicar que una característica o funcionalidad está obsoleta y que se
+eliminará en las próximas versiones.
     %li
       %code Removed
       para las características en desuso que se eliminaron en esta versión.
@@ -117,7 +117,8 @@ seguimiento sobre los próximos cambios.
 
   %ul
     %li
-      La gente puede ver qué cambios podrían esperar en los próximos lanzamientos.
+      La gente puede ver qué cambios podrían esperar en los próximos
+lanzamientos.
     %li
       Al lanzar una nueva versión, tan sólo habría que mover el contenido de
 <code>Unreleased</code> a una sección para la nueva versión.
@@ -165,15 +166,14 @@ cualquier otro cambio sin compatibilidad hacia atrás en tu changelog.
     Fechas confusas
 
   %p
-    Los formatos de fecha regionales varían en todo el mundo y con
-frecuencia es difícil encontrar un formato intuitivo para todos. La
-ventaja de las fechas con el formato <code>2017-07-17</code> es que
-siguen un orden de unidades de mayor a menor: año, mes y día. Este
-formato tampoco coincide de forma ambigua con otros formatos de fecha,
-a diferencia de algunos que intercambian la posición del mes y el día.
-Todo esto, junto al hecho de ser un #{link_to "estándar ISO", iso}, son
-los motivos por los que es el formato de fecha recomendado para las
-entradas del changelog.
+    Los formatos de fecha regionales varían en todo el mundo y con frecuencia es
+difícil encontrar un formato intuitivo para todos. La ventaja de las fechas con
+el formato <code>2017-07-17</code> es que siguen un orden de unidades de mayor a
+menor: año, mes y día. Este formato tampoco coincide de forma ambigua con otros
+formatos de fecha, a diferencia de algunos que intercambian la posición del mes
+y el día. Todo esto, junto al hecho de ser un #{link_to "estándar ISO", iso},
+son los motivos por los que es el formato de fecha recomendado para las entradas
+del changelog.
 
   %aside
     Hay más. Ayúdame a recoger estos anti-patrones
@@ -211,7 +211,7 @@ recopilando las mismas.
 
   %p
     Llámalo <code>CHANGELOG.md</code>. Algunos proyectos utilizan
-    <code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
+<code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
 
   %p
     Si bien es fácil pensar que el nombre de tu archivo de changelog no importa
@@ -232,15 +232,15 @@ convertirlas en notas.
   %p
     Los releases de Github crean un changelog no portable que sólo pueden ser
 mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan
-muy parecidas al formato de <em>Mantenga un changelog</em>, pero tiende a ser
-un poco más complicado.
+muy parecidas al formato de <em>Mantenga un changelog</em>, pero tiende a ser un
+poco más complicado.
 
   %p
     La versión actual de los releases de Github es también discutiblemente no
 muy detectable por los usuarios finales, diferente a los típicos archivos en
-mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, etc.). Otro
-problema menor es que la interfaz actualmente no ofrece enlaces a los registros
-de los commits entre cada lanzamiento.
+mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, etc.). Otro problema
+menor es que la interfaz actualmente no ofrece enlaces a los registros de los
+commits entre cada lanzamiento.
 
   %h4#automatic
     %a.anchor{ href: "#automatic", aria_hidden: "true" }

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -30,21 +30,21 @@ version: 1.0.0
 .answers
   %h3#what
     %a.anchor{ href: "#what", aria_hidden: "true" }
-    ¿Qué es un registro de cambios (change log)?
+    ¿Qué es un registro de cambios (changelog)?
 
   %p
-    Un registro de cambios o “change log” de ahora en adelante, es un archivo que contiene una lista en orden cronológico sobre los cambios que vamos haciendo en cada release (o versión) de nuestro proyecto.
+    Un registro de cambios o “changelog” de ahora en adelante, es un archivo que contiene una lista en orden cronológico sobre los cambios que vamos haciendo en cada release (o versión) de nuestro proyecto.
 
   %h3#why
     %a.anchor{ href: "#why", aria_hidden: "true" }
-    ¿Cuál es el propósito del change log?
+    ¿Cuál es el propósito del changelog?
 
   %p
     Que les sea más fácil a los usuarios y contribuyentes, ver exactamente los cambios notables que se han hecho entre cada versión (o versiones) del proyecto.
 
   %h3#who
     %a.anchor{ href: "#who", aria_hidden: "true" }
-    ¿Quién necesita un change log?
+    ¿Quién necesita un changelog?
 
   %p
     Las personas. Ya sean consumidores o desarrolladores, los usuarios finales del software son seres humanos que les importa que hay en el software. Cuando el software cambia, la gente quiere saber el porqué y el cómo.
@@ -52,7 +52,7 @@ version: 1.0.0
 .good-practices
   %h3#how
     %a.anchor{ href: "#how", aria_hidden: "true" }
-    ¿Como hago un buen change log?
+    ¿Como hago un buen changelog?
 
   %h4#principles
     %a.anchor{ href: "#principles", aria_hidden: "true" }
@@ -117,7 +117,7 @@ version: 1.0.0
 .bad-practices
   %h3#bad-practices
     %a.anchor{ href: "#bad-practices", aria_hidden: "true" }
-    ¿Pueden los change logs ser malos?
+    ¿Pueden los changelogs ser malos?
 
   %p Si. Aquí hay unas maneras en las que pueden ser muy poco útiles.
 
@@ -132,7 +132,7 @@ version: 1.0.0
     El propósito de un commit es documentar un paso en la evolución del código fuente. Algunos proyectos limpian los commits, en otros no.
 
   %p
-    El propósito de una entrada del change log es documentar la notable diferencia, usualmente entre múltiples commits, para comunicarlos claramente a los usuarios finales.
+    El propósito de una entrada del changelog es documentar la notable diferencia, usualmente entre múltiples commits, para comunicarlos claramente a los usuarios finales.
 
   %h4#ignoring-deprecations
     %a.anchor{ href: "#ignoring-deprecations", aria_hidden: "true" }
@@ -142,7 +142,7 @@ version: 1.0.0
     Cuando las personas actualizan de una versión a otra, debería ser extremadamente claro cuando algo se romperá. Debería ser posible actualizar a una versión que liste deprecaciones, remover que está deprecado, luego actualizar a la versión donde las deprecaciones sean remociones.
 
   %p
-    Si no haces nada más, lista deprecaciones, remociones, y cualquier cambio sin compatibilidad hacia atrás en tu change log.
+    Si no haces nada más, lista deprecaciones, remociones, y cualquier cambio sin compatibilidad hacia atrás en tu changelog.
 
 
   %h4#confusing-dates
@@ -150,7 +150,7 @@ version: 1.0.0
     Fechas confusas
 
   %p
-    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code>, sin embargo lo pronuncian distinto. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha, y es un #{link_to "Estandar ISO", iso}. Por lo cual, es el formato de fecha recomendado para change logs.
+    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code>, sin embargo lo pronuncian distinto. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha, y es un #{link_to "Estandar ISO", iso}. Por lo cual, es el formato de fecha recomendado para changelogs.
 
   %aside
     Hay más. Ayudame a recoger estos anti-patrones
@@ -164,14 +164,14 @@ version: 1.0.0
 
   %h4#standard
     %a.anchor{ href: "#standard", aria_hidden: "true" }
-    ¿Hay un formato estandar para los change logs?
+    ¿Hay un formato estandar para los changelogs?
 
   %p
     No realmente. Hay una guía de estilo del GNU, o los dos parrafos del archivo de NOTICIAS <code>guideline</code> del GNU. Ambos son inadecuados o insuficientes.
 
   %p
     Este proyecto apunta a ser
-    = link_to "una mejor convención de change logs.", changelog
+    = link_to "una mejor convención de changelogs.", changelog
     Esto se da observando las buenas prácticas en la comunidad open source y recopilando las mismas.
 
   %p
@@ -181,14 +181,14 @@ version: 1.0.0
 
   %h4#filename
     %a.anchor{ href: "#filename", aria_hidden: "true" }
-    ¿Cómo debería llamarse el archivo de change log?
+    ¿Cómo debería llamarse el archivo de changelog?
 
   %p
     Llamalo <code>CHANGELOG.md</code>. Algunos proyectos utilizan
     <code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
 
   %p
-    Si bien es fácil pensar que el nombre de tu archivo de change log no importa tanto, ¿Por qué hacer dificil para los usuarios finales conseguir de manera consistente los cambios notables?
+    Si bien es fácil pensar que el nombre de tu archivo de changelog no importa tanto, ¿Por qué hacer dificil para los usuarios finales conseguir de manera consistente los cambios notables?
 
   %h4#github-releases
     %a.anchor{ href: "#github-releases", aria_hidden: "true" }
@@ -198,21 +198,21 @@ version: 1.0.0
     Es una gran iniciativa. #{link_to "Los releases de Github", ghr} pueden ser utilizados para convertir simples etiquetas de git (por ejemplo una etiqueta llamada <code>v1.0.0</code>) en ricas notas de release ya sea añadiendo estas manualmente o trayendo los mensajes anotados de las etiquetas de git y convertirlas en notas.
 
   %p
-    Los releases de Github crean un change log no portable que solo pueden ser mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan muy parecidas al formato de Mantenga un Changelog, pero tiende a ser un poco más involucrado.
+    Los releases de Github crean un changelog no portable que solo pueden ser mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan muy parecidas al formato de Mantenga un Changelog, pero tiende a ser un poco más involucrado.
 
   %p
     La versión actual de los releases de Github es también discutiblemente no muy detectable por los usuarios finales, diferente a los típicos archivos en mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, entre otros.). Otro problema menor es que la interfaz actualmente no ofrece enlaces a los registros de los commits entre cada release.
 
   %h4#automatic
     %a.anchor{ href: "#automatic", aria_hidden: "true" }
-    ¿Se pueden analizar gramaticalmente los change logs?
+    ¿Se pueden analizar gramaticalmente los changelogs?
 
   %p
     Es difícil, porque las personas siguen formatos y distintos nombres de archivo muy distintos.
 
   %p
     #{link_to "Vandamme", vandamme} es una gema de Ruby creada por el equipo de 
-    #{link_to "Gemnasium", gemnasium} y que analiza gramaticalmente muchos (pero no todos) los change logs de proyectos open source.
+    #{link_to "Gemnasium", gemnasium} y que analiza gramaticalmente muchos (pero no todos) los changelogs de proyectos open source.
 
 
   %h4#yanked
@@ -220,7 +220,7 @@ version: 1.0.0
     ¿Qué hay sobre los releases retirados?
 
   %p
-    "Yanked releases" son versiones que tuvieron que ser retiradas por un error grave o problema de seguridad. Con frecuencia estas versiones ni siquiera aparecen en los change logs. Deberían. Así es como se deberían mostrarse:
+    "Yanked releases" son versiones que tuvieron que ser retiradas por un error grave o problema de seguridad. Con frecuencia estas versiones ni siquiera aparecen en los changelogs. Deberían. Así es como se deberían mostrarse:
 
   %p <code>## 0.0.5 - 2014-12-13 [YANKED]</code>
 
@@ -230,13 +230,13 @@ version: 1.0.0
 
   %h4#rewrite
     %a.anchor{ href: "#rewrite", aria_hidden: "true" }
-    ¿Deberías volver a escribir un change log?
+    ¿Deberías volver a escribir un changelog?
 
   %p
-    Por supuesto. Siempre hay buenas razones para mejorar el change log. A veces abro "pull requests" para añadir registros faltantes en el change log de proyectos open source.
+    Por supuesto. Siempre hay buenas razones para mejorar el changelog. A veces abro "pull requests" para añadir registros faltantes en el changelog de proyectos open source.
 
   %p
-    También es posible que puedas descubrir que olvidaste comentar sobre un cambio sin compatibilidad hacia atrás en las notas para una versión. En este caso es importante para ti actualizar el change log.
+    También es posible que puedas descubrir que olvidaste comentar sobre un cambio sin compatibilidad hacia atrás en las notas para una versión. En este caso es importante para ti actualizar el changelog.
 
 
   %h4#contribute
@@ -255,4 +255,4 @@ version: 1.0.0
 .press
   %h3 Conversaciones
   %p
-    Fuí al #{link_to "The Changelog podcast", thechangelog} para hablar acerca de porqué a los mantenedores y contribuidores deberían importarles los change logs, y también acerca de las motivaciones detrás de este proyecto.
+    Fuí al #{link_to "The Changelog podcast", thechangelog} para hablar acerca de porqué a los mantenedores y contribuidores deberían importarles los changelogs, y también acerca de las motivaciones detrás de este proyecto.

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -52,7 +52,7 @@ version: 1.0.0
 .good-practices
   %h3#how
     %a.anchor{ href: "#how", aria_hidden: "true" }
-    ¿Como hago un buen changelog?
+    ¿Cómo hago un buen changelog?
 
   %h4#principles
     %a.anchor{ href: "#principles", aria_hidden: "true" }
@@ -139,7 +139,7 @@ version: 1.0.0
     Ignorando Deprecaciones
 
   %p
-    Cuando las personas actualizan de una versión a otra, debería ser extremadamente claro cuando algo se romperá. Debería ser posible actualizar a una versión que liste deprecaciones, remover que está deprecado, luego actualizar a la versión donde las deprecaciones sean remociones.
+    Cuando las personas actualizan de una versión a otra, debería ser extremadamente claro cuando algo se romperá. Debería ser posible actualizar a una versión que liste deprecaciones, remover qué está deprecado, luego actualizar a la versión donde las deprecaciones sean remociones.
 
   %p
     Si no haces nada más, lista deprecaciones, remociones, y cualquier cambio sin compatibilidad hacia atrás en tu changelog.
@@ -153,7 +153,7 @@ version: 1.0.0
     En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code>, sin embargo lo pronuncian distinto. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha, y es un #{link_to "Estandar ISO", iso}. Por lo cual, es el formato de fecha recomendado para changelogs.
 
   %aside
-    Hay más. Ayudame a recoger estos anti-patrones
+    Hay más. Ayúdame a recoger estos anti-patrones
     = link_to "abriendo un issue", "#issues"
     o un pull request.
 
@@ -164,7 +164,7 @@ version: 1.0.0
 
   %h4#standard
     %a.anchor{ href: "#standard", aria_hidden: "true" }
-    ¿Hay un formato estandar para los changelogs?
+    ¿Hay un formato estándar para los changelogs?
 
   %p
     No realmente. Hay una guía de estilo del GNU, o los dos parrafos del archivo de NOTICIAS <code>guideline</code> del GNU. Ambos son inadecuados o insuficientes.
@@ -184,7 +184,7 @@ version: 1.0.0
     ¿Cómo debería llamarse el archivo de changelog?
 
   %p
-    Llamalo <code>CHANGELOG.md</code>. Algunos proyectos utilizan
+    Llámalo <code>CHANGELOG.md</code>. Algunos proyectos utilizan
     <code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
 
   %p

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -1,6 +1,6 @@
 ---
-description: Mantenga un Changelog
-title: Mantenga un Changelog
+description: Mantenga un changelog
+title: Mantenga un changelog
 language: es-ES
 version: 1.0.0
 ---
@@ -18,8 +18,8 @@ version: 1.0.0
 
 .header
   .title
-    %h1 Mantenga un Changelog
-    %h2 No dejes que tus amigos copien y peguen git logs en los CHANGELOGs™
+    %h1 Mantenga un changelog
+    %h2 No dejes que tus amigos usen el registro de git en los changelogs.
 
   = link_to changelog do
     Versión
@@ -33,21 +33,21 @@ version: 1.0.0
     ¿Qué es un registro de cambios (changelog)?
 
   %p
-    Un registro de cambios o “changelog” de ahora en adelante, es un archivo que contiene una lista en orden cronológico sobre los cambios que vamos haciendo en cada release (o versión) de nuestro proyecto.
+    Un registro de cambios, «changelog» de ahora en adelante, es un archivo que contiene una lista cronológicamente ordenada de los cambios más destacables para cada versión de un proyecto.
 
   %h3#why
     %a.anchor{ href: "#why", aria_hidden: "true" }
-    ¿Cuál es el propósito del changelog?
+    ¿Por qué mantener un changelog?
 
   %p
-    Que les sea más fácil a los usuarios y contribuyentes, ver exactamente los cambios notables que se han hecho entre cada versión (o versiones) del proyecto.
+    Para facilitar a los usuarios y colaboradores ver exactamente qué cambios reseñables se han realizados entre cada versión del proyecto.
 
   %h3#who
     %a.anchor{ href: "#who", aria_hidden: "true" }
     ¿Quién necesita un changelog?
 
   %p
-    Las personas. Ya sean consumidores o desarrolladores, los usuarios finales del software son seres humanos que les importa que hay en el software. Cuando el software cambia, la gente quiere saber el porqué y el cómo.
+    Las personas. Ya sean consumidores o desarrolladores, los usuarios finales del software son seres humanos a los que le importa lo que hay en el software. Cuando el software cambia, la gente quiere saber el porqué y el cómo.
 
 .good-practices
   %h3#how
@@ -60,7 +60,7 @@ version: 1.0.0
 
   %ul
     %li
-      Están hecho para los seres humanos, no para las máquinas.
+      Están hechos <em>para los seres humanos</em>, no para las máquinas.
     %li
       Debe haber una entrada para cada versión.
     %li
@@ -68,11 +68,11 @@ version: 1.0.0
     %li
       Versiones y secciones deben ser enlazables.
     %li
-      La última versión viene primero.
+      La última versión va primero.
     %li
-      La fecha de publicación de cada versión es mostrada.
+      Debe mostrar la fecha de publicación de cada versión.
     %li
-      Se menciona explícitamente si el proyecto sigue la convención del #{link_to "Versionamiento Semántico", semver}.
+      Indicar si el proyecto sigue el #{link_to "Versionamiento Semántico", semver}.
 
   %a.anchor{ href: "#types", aria_hidden: "true" }
   %h4#types Tipos de cambios
@@ -86,13 +86,13 @@ version: 1.0.0
       para los cambios en las funcionalidades existentes.
     %li
       %code Deprecated
-      para indicar que una característica está obsoleta y que se eliminará en las próximas versiones.
+      para indicar que una característica o funcionalidad está obsoleta y que se eliminará en las próximas versiones.
     %li
       %code Removed
       para las características en desuso que se eliminaron en esta versión.
     %li
       %code Fixed
-      para correcciones y bugs.
+      para corrección de errores.
     %li
       %code Security
       en caso de vulnerabilidades.
@@ -101,61 +101,59 @@ version: 1.0.0
 
   %h3#effort
     %a.anchor{ href: "#effort", aria_hidden: "true" }
-    ¿Cómo puedo minimizar el esfuerzo requerido?
+    ¿Cómo puedo minimizar el esfuerzo requerido para mantener el changelog?
 
   %p
-    Siempre mantén una sección con el nombre <code>Unreleased</code> para hacer un seguimiento sobre los próximos cambios.
+    Mantén una sección con el nombre <code>Unreleased</code> para hacer un seguimiento sobre los próximos cambios.
 
   %p Esto nos puede servir para dos cosas:
 
   %ul
     %li
-      La gente puede ver qué cambios podrían esperar en los próximos releases.
+      La gente puede ver qué cambios podrían esperar en los próximos lanzamientos.
     %li
-      Una vez que queramos hacer un release, sólo habría que mover la sección <code>Unreleased</code> y sus cambios en una nueva sección con la respectiva versión.
+      Al lanzar una nueva versión, tan sólo habría que mover el contenido de <code>Unreleased</code> a una sección para la nueva versión.
 
 .bad-practices
   %h3#bad-practices
     %a.anchor{ href: "#bad-practices", aria_hidden: "true" }
     ¿Pueden los changelogs ser malos?
 
-  %p Si. Aquí hay unas maneras en las que pueden ser muy poco útiles.
+  %p Sí. A continuación algunas formas en las que pueden ser muy poco útiles.
 
   %h4#log-diffs
     %a.anchor{ href: "#log-diffs", aria_hidden: "true" }
     Usar un diff de los logs de los commits
 
   %p
-    Usar un diff de los logs de los commits es una mala idea: están llenos de ruido. Cosas como hacer <em>merge</em> de los commits, commits con títulos oscuros, cambios de documentación, entre otros.
+    Usar un diff de los logs de los commits es una mala idea: están llenos de ruido. Cosas como hacer <em>merge</em> de los commits, commits con títulos poco claros, cambios de documentación, etc.
 
   %p
-    El propósito de un commit es documentar un paso en la evolución del código fuente. Algunos proyectos limpian los commits, en otros no.
+    El propósito de un commit es documentar un paso en la evolución del código fuente. Algunos proyectos limpian los commits, otros no.
 
   %p
-    El propósito de una entrada del changelog es documentar la notable diferencia, usualmente entre múltiples commits, para comunicarlos claramente a los usuarios finales.
+    El propósito de una entrada en el changelog es documentar cambios notables, usualmente entre múltiples commits, para comunicarlos claramente a los usuarios finales.
 
   %h4#ignoring-deprecations
     %a.anchor{ href: "#ignoring-deprecations", aria_hidden: "true" }
-    Ignorando Deprecaciones
+    Ignorar <em>funcionalidades sin soporte</em>
 
   %p
-    Cuando las personas actualizan de una versión a otra, debería ser extremadamente claro cuando algo se romperá. Debería ser posible actualizar a una versión que liste deprecaciones, remover qué está deprecado, luego actualizar a la versión donde las deprecaciones sean remociones.
-
+    Cuando la gente actualiza de una version a otra, debería estar bastante claro cuándo algo se va a romper. Debería ser posible actualizar a una versión que detalle funcionalidades sin soporte, eliminar lo que está obsoleto y actualizar a la versión donde esas funcionalidades han sido eliminadas.
   %p
-    Si no haces nada más, lista deprecaciones, remociones, y cualquier cambio sin compatibilidad hacia atrás en tu changelog.
-
+    Si no haces nada más, enumera lo que queda obsoleto, lo eliminado y cualquier otro cambio sin compatibilidad hacia atrás en tu changelog.
 
   %h4#confusing-dates
     %a.anchor{ href: "#confusing-dates", aria_hidden: "true" }
     Fechas confusas
 
   %p
-    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code>, sin embargo lo pronuncian distinto. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha, y es un #{link_to "Estandar ISO", iso}. Por lo cual, es el formato de fecha recomendado para changelogs.
+    En los EE.UU., la gente pone primero el mes (<code>06-02-2012</code> para el 2 de junio del 2012), mientras que muchas personas en el resto del mundo escriben de una manera muy robótica <code>2 Junio 2012</code> aunque lo proununcien diferente. <code>2012-06-02</code> funciona logicamente desde el más grande al más pequeño, no se solapa de maneras ambiugas con otros formatos de fecha y es un #{link_to "Estándar ISO", iso}. Por lo cual, es el formato de fecha recomendado para el changelog.
 
   %aside
     Hay más. Ayúdame a recoger estos anti-patrones
     = link_to "abriendo un issue", "#issues"
-    o un pull request.
+    o una <em>pull request</em>.
 
 .frequently-asked-questions
   %h3#frequently-asked-questions
@@ -164,14 +162,14 @@ version: 1.0.0
 
   %h4#standard
     %a.anchor{ href: "#standard", aria_hidden: "true" }
-    ¿Hay un formato estándar para los changelogs?
+    ¿Hay un formato estándar para el changelog?
 
   %p
-    No realmente. Hay una guía de estilo del GNU, o los dos parrafos del archivo de NOTICIAS <code>guideline</code> del GNU. Ambos son inadecuados o insuficientes.
+    No. Hay una guía de estilo del GNU o los dos parrafos del archivo <code>guideline</code> del <em>GNU NEWS</em>. Ambos son inadecuados o insuficientes.
 
   %p
     Este proyecto apunta a ser
-    = link_to "una mejor convención de changelogs.", changelog
+    = link_to "una mejor convención de changelog.", changelog
     Esto se da observando las buenas prácticas en la comunidad open source y recopilando las mismas.
 
   %p
@@ -188,44 +186,44 @@ version: 1.0.0
     <code>HISTORY</code>, <code>NEWS</code> o <code>RELEASES</code>.
 
   %p
-    Si bien es fácil pensar que el nombre de tu archivo de changelog no importa tanto, ¿Por qué hacer dificil para los usuarios finales conseguir de manera consistente los cambios notables?
+    Si bien es fácil pensar que el nombre de tu archivo de changelog no importa tanto, ¿Por qué hacer difícil para los usuarios finales conseguir de manera consistente los cambios notables?
 
   %h4#github-releases
     %a.anchor{ href: "#github-releases", aria_hidden: "true" }
     ¿Y qué hay de los releases de Github?
 
   %p
-    Es una gran iniciativa. #{link_to "Los releases de Github", ghr} pueden ser utilizados para convertir simples etiquetas de git (por ejemplo una etiqueta llamada <code>v1.0.0</code>) en ricas notas de release ya sea añadiendo estas manualmente o trayendo los mensajes anotados de las etiquetas de git y convertirlas en notas.
+    Es una gran iniciativa. #{link_to "Los releases de Github", ghr} pueden ser utilizados para convertir simples etiquetas de git (por ejemplo una etiqueta llamada <code>v1.0.0</code>) en ricas notas de lanzamiento ya sea añadiendo estas manualmente o trayendo los mensajes anotados de las etiquetas de git y convertirlas en notas.
 
   %p
-    Los releases de Github crean un changelog no portable que solo pueden ser mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan muy parecidas al formato de Mantenga un Changelog, pero tiende a ser un poco más involucrado.
+    Los releases de Github crean un changelog no portable que sólo pueden ser mostrados a usuarios dentro del contexto de Github. Es posible hacer que luzcan muy parecidas al formato de <em>Mantenga un changelog</em>, pero tiende a ser un poco más complicado.
 
   %p
-    La versión actual de los releases de Github es también discutiblemente no muy detectable por los usuarios finales, diferente a los típicos archivos en mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, entre otros.). Otro problema menor es que la interfaz actualmente no ofrece enlaces a los registros de los commits entre cada release.
+    La versión actual de los releases de Github es también discutiblemente no muy detectable por los usuarios finales, diferente a los típicos archivos en mayúsculas (<code>README</code>, <code>CONTRIBUTING</code>, etc.). Otro problema menor es que la interfaz actualmente no ofrece enlaces a los registros de los commits entre cada lanzamiento.
 
   %h4#automatic
     %a.anchor{ href: "#automatic", aria_hidden: "true" }
     ¿Se pueden analizar gramaticalmente los changelogs?
 
   %p
-    Es difícil, porque las personas siguen formatos y distintos nombres de archivo muy distintos.
+    Es difícil, porque las personas usan formatos y nombres de archivos muy distintos.
 
   %p
     #{link_to "Vandamme", vandamme} es una gema de Ruby creada por el equipo de 
-    #{link_to "Gemnasium", gemnasium} y que analiza gramaticalmente muchos (pero no todos) los changelogs de proyectos open source.
+    #{link_to "Gemnasium", gemnasium} que analiza gramaticalmente muchos (pero no todos) los changelogs de proyectos open source.
 
 
   %h4#yanked
     %a.anchor{ href: "#yanked", aria_hidden: "true" }
-    ¿Qué hay sobre los releases retirados?
+    ¿Qué hay sobre las versiones retiradas?
 
   %p
-    "Yanked releases" son versiones que tuvieron que ser retiradas por un error grave o problema de seguridad. Con frecuencia estas versiones ni siquiera aparecen en los changelogs. Deberían. Así es como se deberían mostrarse:
+    «Yanked releases» son versiones que tuvieron que ser retiradas por un error grave o problema de seguridad. Con frecuencia estas versiones ni siquiera aparecen en los changelogs. Deberían. Así es como deberían mostrarse:
 
   %p <code>## 0.0.5 - 2014-12-13 [YANKED]</code>
 
   %p
-    La etiqueta <code>[YANKED]</code> va entre corchetes por una razón, es importante que destaque, y el hecho de estar rodeado por corchetes lo hace más fácil de localizar programáticamente.
+    La etiqueta <code>[YANKED]</code> está destacada por una razón: es importante que destaque. El hecho de estar entre corchetes la hace también más fácil de localizar programáticamente.
 
 
   %h4#rewrite
@@ -233,10 +231,10 @@ version: 1.0.0
     ¿Deberías volver a escribir un changelog?
 
   %p
-    Por supuesto. Siempre hay buenas razones para mejorar el changelog. A veces abro "pull requests" para añadir registros faltantes en el changelog de proyectos open source.
+    Por supuesto. Siempre hay buenas razones para mejorar el changelog. A veces abro «pull requests» para añadir registros faltantes en el changelog de proyectos open source.
 
   %p
-    También es posible que puedas descubrir que olvidaste comentar sobre un cambio sin compatibilidad hacia atrás en las notas para una versión. En este caso es importante para ti actualizar el changelog.
+    También es posible que puedas descubrir que olvidaste señalar un cambio sin compatibilidad hacia atrás en las notas para una versión. En este caso es importante para ti actualizar el changelog.
 
 
   %h4#contribute
@@ -244,7 +242,7 @@ version: 1.0.0
     ¿Cómo puedo contribuir?
 
   %p
-    Este documento no es la <strong>verdad absoluta</strong> es mi cuidadosa opinión, junto con información y ejemplos que recogí.
+    Este documento no es la <strong>verdad absoluta</strong>; es mi cuidadosa opinión, junto con información y ejemplos que recopilé.
 
   %p
     Esto es porque quiero que la comunidad llegue a un consenso. Creo que la discusión es tan importante como el resultado final.
@@ -255,4 +253,4 @@ version: 1.0.0
 .press
   %h3 Conversaciones
   %p
-    Fuí al #{link_to "The Changelog podcast", thechangelog} para hablar acerca de porqué a los mantenedores y contribuidores deberían importarles los changelogs, y también acerca de las motivaciones detrás de este proyecto.
+    Fui a #{link_to "The Changelog podcast", thechangelog} para hablar acerca del porqué los mantenedores y colaboradores deberían preocuparse por los changelogs, y también acerca de las motivaciones detrás de este proyecto.


### PR DESCRIPTION
Hi everyone!

I am making this PR in order to improve a little the Spanish translation. I would like to have the feedback of @ZeliosAriex and @leocabeza (who made current Spanish translations) apart from someone else that wants to help.

I also want to discuss about some specific words and achieve an agreement about which could be the best translation for them

* **curated**; in the context of  _a file which contains a curated, chronologically ordered list_ I believe that `saneada` or `limpia`  is the meaning of this word. However, I am not sure about if we should include this translation in the sentence. Probably _un fichero que contiene una lista conológicamente ordeanda_ could be enough.

* **deprecations**; this is a difficult word to translate.  I have no problem to keep it as it in the Spanish version, maybe emphasizing it. But if we want to translate it to Spanish, we can not use `deprecación` or `deprecaciones` because it is a Spanish word with a different meaning ([see RAE definition](http://dle.rae.es/?id=CFmWKG6)). In fact, other guys already discussed this topic (see  for example [1](https://twitter.com/pedrogk/status/855484262958673921),  [2](https://twitter.com/seppo0011/status/726089723647823873) or [3](https://twitter.com/arturotena/status/596737511579209728) at Twitter).

  So, I will propose to use `obsoleto/a` or `funcionalidad(es) sin soporte`. Also `desaprobaciones` could be an option, but honestly it sounds weird to me.

* **contributors**; while `contribuyente` could be used as the adjective `contributor`, as a noun (according to [RAE definition](http://dle.rae.es/?id=AeTqHgU)) is the person that has to pay a tax. So, IMO, is better to use `colaboradores` in this context.

* **mention**; in the `Guides principles` I prefer to use `Indicar` over `Mencionar`.

* **pull request**; it could be translated as `petición de cambios`, but IMO it is not necessary.

Apart from this, I also agree with @callumlocke about the issue with ["Confusing dates"](https://github.com/olivierlacan/keep-a-changelog/issues/178) paragraph and it could be written simpler. Even more, something similar to the one addressed in the previous version (0.3.0) could be more clear:

  **`en:`**
  > The format YYYY-MM-DD must be used. It is a [ISO standard](http://www.iso.org/iso/home/standards/iso8601.htm), international, [sensible](https://xkcd.com/1179/) and language independent.

  **`es:`**
  > Se debe usar el formato de fecha AAAA-MM-DD. Es un [estándar ISO](http://www.iso.org/iso/home/standards/iso8601.htm), internacional, [sensato](https://xkcd.com/1179/) e independiente del lenguaje.

Finally, I must admit that the paragraph [Ignoring deprecations](http://keepachangelog.com/en/1.0.0/#ignoring-deprecations) is a little complicated for me to understand.

PS: I am also going to do a friendly ping to @backpackerhh because I know he has free time and I am pretty sure that he can give us a good review.