### PR TITLE
BUG: Update Swedish (sv) translation of yanked-section.

### DIFF
--- a/source/sv/1.0.0/index.html.haml
+++ b/source/sv/1.0.0/index.html.haml
@@ -254,12 +254,13 @@ version: 1.0.0
 
   %h4#yanked
     %a.anchor{ href: "#yanked", aria_hidden: "true" }
-    Hur är det med brådskande utgåvor ("yanked")?
+    Hur är det med återtagna utgåvor ("yanked")?
 
   %p
-    Brådskande utgåvor är versioner som måste släppas på grund av alvarliga
-    buggar eller säkerhetsproblem. Oftast brukar dessa versioner inte ens
-    finnas med i ändringsloggarna. De borde det. Så här borde du visa dem:
+    Återtagna utgåvor är versioner som måste tas tillbaka på grund av
+    allvarliga buggar eller säkerhetsproblem. Oftast brukar dessa versioner
+    inte ens finnas med i ändringsloggarna. De borde det. Så här borde du
+    visa dem:
 
   %p <code>## 0.0.5 - 2014-12-13 [YANKED]</code>
 


### PR DESCRIPTION
The translation described something closer to a rushed release and not
the opposite, what happens when you rush a relase.