### PR TITLE
Add reference to Node changelog parser

### DIFF
--- a/source/en/1.0.0/index.html.haml
+++ b/source/en/1.0.0/index.html.haml
@@ -17,6 +17,7 @@ version: 1.0.0
 - ghr = "https://help.github.com/articles/creating-releases/"
 - gnustyle = "https://www.gnu.org/prep/standards/html_node/Style-of-Change-Logs.html#Style-of-Change-Logs"
 - gnunews = "https://www.gnu.org/prep/standards/html_node/NEWS-File.html#NEWS-File"
+- changelog_parser = "https://github.com/hypermodules/changelog-parser"
 
 .header
   .title
@@ -258,6 +259,10 @@ version: 1.0.0
     #{link_to "Vandamme", vandamme} is a Ruby gem created by the
     #{link_to "Gemnasium", gemnasium} team and which parses many (but
     not all) open source project changelogs.
+
+  %p
+    #{link_to "changelog-parser", changelog_parser} is a changelog parser for Node.
+    Supports different time formats. Also could work in cli.
 
 
   %h4#yanked


### PR DESCRIPTION
Hey guys. Thanks for maintaining this project.

For automated creation GitHub release notes we are (in [@zattoo](https://github.com/zattoo)) using and contributing to [changelog-parser](https://github.com/hypermodules/changelog-parser). This is Node module, also could be used as cli tool.

Would be nice to share it, I guess.
