### PR TITLE
Ampersands must be escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "Frequently Asked Questions" section.
 - New "Guiding Principles" sub-section to "How do I make a changelog?".
 - Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
-- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- German translation from [@mpbzh](https://github.com/mpbzh) &amp; [@Art4](https://github.com/Art4).
 - Italian translation from [@azkidenz](https://github.com/azkidenz).
 - Swedish translation from [@magol](https://github.com/magol).
 - Turkish translation from [@karalamalar](https://github.com/karalamalar).


### PR DESCRIPTION
According to the [markdown syntax](https://daringfireball.net/projects/markdown/syntax), ampersands must be escaped as entities: `&amp;`. 