### PR TITLE
Center the `⌄` and `-` in the FAQ

### DIFF
--- a/source/assets/stylesheets/sections.sass
+++ b/source/assets/stylesheets/sections.sass
@@ -142,6 +142,8 @@ div.frequently-asked-questions
       font-size: 2.8em
       line-height: 0.4
       margin-right: -0.3em
+      width: 1em
+      text-align: center
 
 
     &.is-visible:after


### PR DESCRIPTION
Aligned the `⌄` and `-` in the FAQ (it was mildly annoying me)

Before:
![image](https://user-images.githubusercontent.com/662538/71122019-ee709280-21df-11ea-8871-c9a6fb24ff58.png)



After:
![image](https://user-images.githubusercontent.com/662538/71121988-dbf65900-21df-11ea-90c7-d85bb713c4a8.png)

