### PR TITLE
removed "tm" symbol in Russian l10n

### DIFF
--- a/source/ru/1.0.0/index.html.haml
+++ b/source/ru/1.0.0/index.html.haml
@@ -18,7 +18,7 @@ version: 1.0.0
 .header
   .title
     %h1 Ведите CHANGELOG
-    %h2 Не позволяйте друзьям сливать логи гита в CHANGELOG™
+    %h2 Не позволяйте друзьям сливать логи гита в CHANGELOG
 
   = link_to changelog do
     Version


### PR DESCRIPTION
removed stupid trademark symbol in Russian localization, cause... you know, "changelog" is not a trademark.