### PR TITLE
Headings should be surrounded by blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2019-02-15
 
 ### Added
+
 - Changelog inconsistency section in Bad Practices
 
 ## [1.0.0] - 2017-06-20


### PR DESCRIPTION
MD022: Headings should be surrounded by blank lines.

All headings must have a blank line both before and after.