### PR TITLE
Fix markdown validation issues in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Danish translation from [@frederikspang](https://github.com/frederikspang).
-- Georgian translation from [@tatocaster ](https://github.com/tatocaster).
+- Georgian translation from [@tatocaster](https://github.com/tatocaster).
 - Changelog inconsistency section in Bad Practices
 
 ### Changed
+
 - Fixed typos in Italian translation from [@lorenzo-arena](https://github.com/lorenzo-arena).
 - Fixed typos in Indonesian translation from [@ekojs](https://github.com/ekojs).
 


### PR DESCRIPTION
According to markdown lint (https://dlaa.me/markdownlint/) there are several linting issues with the Changelog:
Line 15 - MD039 Spaces inside link text [Context: "[@tatocaster ]"]
Line 18 - MD022 Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "### Changed"]
Line 19 - MD032 Lists should be surrounded by blank lines [Context: "- Fixed typos in Italian trans..."]
