### PR TITLE
State the date format explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+This changlog uses the [ISO 8601 date format](https://www.iso.org/iso-8601-date-and-time-format.html) of (YYYY-MM-DD).
+
 ## [Unreleased]
 
 ## [1.1.0] - 2019-02-15


### PR DESCRIPTION
#### Problem

The ISO 8601 date format is ambiguous for 132 of the days of each year (about a third).

For example 2019-02-10 which is it YYYY-MM-DD or YYYY-DD-MM.  The changelog does not say.

#### Proposed Solution

Explicitly state the date format.

#### Example

This commit is an example solution.