### PR TITLE
Update hardcoded links to point to latest specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 


### PR DESCRIPTION
* Change hardcoded links to make them dynamic; to point to latest spec doc versions
** keepachangelog.com 1.0.0 -> latest
** semver.org 2.0.0 -> latest