### PR TITLE
Headings should be surrounded by blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changelog inconsistency section in Bad Practices
 
 ### Changed
+
 - Fixed typos in Italian translation from [@lorenzo-arena](https://github.com/lorenzo-arena).
 - Fixed typos in Indonesian translation from [@ekojs](https://github.com/ekojs).
 


### PR DESCRIPTION
MD022: Headings should be surrounded by blank lines.

All headings must have a blank line both before and after.