### PR TITLE
Fix typo in id-ID translation

### DIFF
--- a/source/id-ID/1.0.0/index.html.haml
+++ b/source/id-ID/1.0.0/index.html.haml
@@ -91,7 +91,7 @@ version: 1.0.0
       %code Changed/Diubah
       untuk perubahan di fitur yang sudah ada.
     %li
-      %code Deprecated/Akan Dhilangkan
+      %code Deprecated/Akan Dihilangkan
       untuk fitur yang akan dihapus dalam waktu dekat.
     %li
       %code Removed/Dihilangkan
@@ -141,8 +141,6 @@ version: 1.0.0
     changelog terlalu berisik dan susah dibaca.
 
   %p
-    <em>The purpose of a commit is to document a step in the evolution of
-    the source code. Some projects clean up commits, some don't</em>.
     Tujuan utama dari commit adalah untuk mencatat setiap perubahan dari source
     code. Beberapa proyek merapikan commitnya, beberapa tidak.
 


### PR DESCRIPTION
This PR fix typo in indonesian translation.

* Word from `Dhilangkan` to `Dihilangkan`
*  Remove unnecessary english paragraph that already translated.
  `Tujuan utama dari commit adalah untuk mencatat setiap perubahan dari source code. Beberapa proyek merapikan commitnya, beberapa tidak.` is the translation of `The purpose of a commit is to document a step in the evolution of the source code. Some projects clean up commits, some don't.`

