### PR TITLE
Anchor to the issues replaced with a valid link

### DIFF
--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -187,7 +187,7 @@ version: 1.0.0
 
   %aside
     Hay más. Ayúdame a recoger estos anti-patrones
-    = link_to "abriendo un issue", "#issues"
+    = link_to "abriendo un issue", issues
     o una <em>pull request</em>.
 
 .frequently-asked-questions

--- a/source/fr/1.0.0/index.html.haml
+++ b/source/fr/1.0.0/index.html.haml
@@ -183,7 +183,7 @@ version: 1.0.0
 
   %aside
     Il y en a d’autres. Aidez-moi à collecter ces antipatrons en
-    #{link_to "ouvrant une issue", "#issues"} ou une pull request.
+    #{link_to "ouvrant une issue", issues} ou une pull request.
 
 .frequently-asked-questions
   %h3#frequently-asked-questions

--- a/source/ru/1.0.0/index.html.haml
+++ b/source/ru/1.0.0/index.html.haml
@@ -181,7 +181,7 @@ version: 1.0.0
 
   %aside
     Есть кое-что ещё. Помогите мне собрать эти антипаттерны,
-    подав #{link_to "заявку о наличии проблемы", "#issues"}
+    подав #{link_to "заявку о наличии проблемы", issues}
     или pull request.
 
 .frequently-asked-questions

--- a/source/ru/1.1.0/index.html.haml
+++ b/source/ru/1.1.0/index.html.haml
@@ -195,7 +195,7 @@ version: 1.1.0
 
   %aside
     Есть кое-что ещё. Помогите мне собрать эти антипаттерны,
-    подав #{link_to "заявку о наличии проблемы", "#issues"}
+    подав #{link_to "заявку о наличии проблемы", issues}
     или pull request.
 
 .frequently-asked-questions


### PR DESCRIPTION
At the moment, the link to questions leads to a `#issues` anchor, instead of a link to the GitHub issues page.