### PR TITLE
Change the Swedish title to För…

### DIFF
--- a/source/sv/1.0.0/index.html.haml
+++ b/source/sv/1.0.0/index.html.haml
@@ -1,6 +1,6 @@
 ---
-description: Håll en ändringslogg
-title: Håll en ändringslogg
+description: För en ändringslogg
+title: För en ändringslogg
 language: sv
 version: 1.0.0
 ---
@@ -19,7 +19,7 @@ version: 1.0.0
 
 .header
   .title
-    %h1 Håll en ändringslogg
+    %h1 För en ändringslogg
     %h2 Låt inte dina vänner slänga in git-loggar i ändringsloggar.
 
   = link_to changelog do
@@ -232,7 +232,7 @@ version: 1.0.0
   %p
     GitHub Releases skapar en icke porterbar ändringslogg som enbart kan visas
     för användare på GitHub. Det är möjligt att formatera det ungefär som på
-    Håll en ändringslogg-formatet, men det tendera att bli lite mer invecklat.
+    För en ändringslogg-formatet, men det tendera att bli lite mer invecklat.
 
   %p
     Nuvarande version av GitHub releases är möjligtvis också lite svår att


### PR DESCRIPTION
This PR changes the Swedish title word "Håll" to "För". "Håll" is a litteral translation (approx "Hold a changelog") while "För" is better.