### PR TITLE
HTML changes to languages

### DIFF
--- a/source/ar/1.0.0/index.html.haml
+++ b/source/ar/1.0.0/index.html.haml
@@ -24,7 +24,7 @@ p.yanked {direction:ltr;text-align:right}
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/cs/1.0.0/index.html.haml
+++ b/source/cs/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verze
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/da/1.1.0/index.html.haml
+++ b/source/da/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/de/1.0.0/index.html.haml
+++ b/source/de/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/en/1.0.0/index.html.haml
+++ b/source/en/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -14,7 +14,7 @@ version: 1.0.0
     Versión
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/fa-IR/1.0.0/index.html.haml
+++ b/source/fa-IR/1.0.0/index.html.haml
@@ -21,7 +21,7 @@ pre {direction:ltr;text-align:left}
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/fr/1.0.0/index.html.haml
+++ b/source/fr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/fr/1.1.0/index.html.haml
+++ b/source/fr/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/hr/1.0.0/index.html.haml
+++ b/source/hr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzija
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/id-ID/1.0.0/index.html.haml
+++ b/source/id-ID/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versi
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/it-IT/1.0.0/index.html.haml
+++ b/source/it-IT/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versione
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ja/1.0.0/index.html.haml
+++ b/source/ja/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ja/1.1.0/index.html.haml
+++ b/source/ja/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ka/1.0.0/index.html.haml
+++ b/source/ka/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ko/1.0.0/index.html.haml
+++ b/source/ko/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -7,8 +7,8 @@
 - newer_version_available = File.exist?("source/#{language_code}/#{$last_version}")
 
 !!! 5
-%html
-  %head{ lang: current_page.data.language }
+%html{ lang: current_page.data.language }
+  %head
     %meta{ charset: 'utf-8' }
     %meta{ content: 'IE=edge', 'http-equiv' => 'X-UA-Compatible' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }

--- a/source/nb/1.1.0/index.html.haml
+++ b/source/nb/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versjon
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/nl/1.0.0/index.html.haml
+++ b/source/nl/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versie
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/nl/1.1.0/index.html.haml
+++ b/source/nl/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versie
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/pl/1.0.0/index.html.haml
+++ b/source/pl/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Wersja
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/pt-BR/1.0.0/index.html.haml
+++ b/source/pt-BR/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ru/1.0.0/index.html.haml
+++ b/source/ru/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/ru/1.1.0/index.html.haml
+++ b/source/ru/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/sk/1.0.0/index.html.haml
+++ b/source/sk/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzia
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/sr/1.0.0/index.html.haml
+++ b/source/sr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzija
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/sv/1.0.0/index.html.haml
+++ b/source/sv/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/tr-TR/1.0.0/index.html.haml
+++ b/source/tr-TR/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/tr-TR/1.1.0/index.html.haml
+++ b/source/tr-TR/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/uk/1.0.0/index.html.haml
+++ b/source/uk/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/zh-CN/1.0.0/index.html.haml
+++ b/source/zh-CN/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what

--- a/source/zh-TW/1.0.0/index.html.haml
+++ b/source/zh-TW/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: en }= File.read("CHANGELOG.md")
 
 .answers
   %h3#what


### PR DESCRIPTION
This moves the language attribute from head to html root and adds language attributes to the changelog examples on the translated pages.