### PR TITLE
Two fixes for translations on website

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -97,7 +97,7 @@ $languages = {
   },
   "sv"    => {
     name: "Svenska",
-    notice: "Den senaste versionen (#{$last_version}) är ännu inte tillgänglig på Svenska,
+    notice: "Den senaste versionen (#{$last_version}) är ännu inte tillgänglig på svenska,
     men du kan <a href='/en/'>läsa det på engelska</a> och även <a
     href='#{issues_url}'>hjälpa till att översätta det</a>."
   },

--- a/source/fr/1.1.0/index.html.haml
+++ b/source/fr/1.1.0/index.html.haml
@@ -2,7 +2,7 @@
 description: Tenez un Changelog
 title: Tenez un Changelog
 language: fr
-version: 1.0.0
+version: 1.1.0
 ---
 .header
   .title


### PR DESCRIPTION
- 078613e202a359f8c6769bb3a68568baa580c8cf Fixes a typo that caused the latest French translation to be recognised as the wrong version.
- 511a816dffac322d1a7ba0270f64c56cdc80116a Fixes the fact that languages should be written with lower-case letter in Swedish.