### PR TITLE
fix: wrong linked data (issues) in index

### DIFF
--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -182,7 +182,7 @@ version: 1.1.0
 
   %aside
     There’s more. Help me collect these antipatterns by
-    = link_to "opening an issue", data.links.issue
+    = link_to "opening an issue", data.links.issues
     or a pull request.
 
 .frequently-asked-questions


### PR DESCRIPTION
I believe the error in the link "[opening an issue](https://keepachangelog.com/en/1.1.0/#)" of [upstream](https://keepachangelog.com/en/1.1.0/#bad-practices) is the missing s at issue:
data.links.issue -> data.links.issues

I don’t know if index.html.haml was the correct file to edit though, let me know.