### PR TITLE
Fixed links to GitHub repo

### DIFF
--- a/data/links.json
+++ b/data/links.json
@@ -1,6 +1,6 @@
 {
   "changelog": "https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md",
-  "gh": "https://github.com/olivierlacan/keep-a-changelog",
+  "repo": "https://github.com/olivierlacan/keep-a-changelog",
   "issues": "https://github.com/olivierlacan/keep-a-changelog/issues",
   "semver": "https://semver.org/",
   "shields": "https://shields.io/",


### PR DESCRIPTION
I noticed that the links to GitHub were linking to '#'. I've fixed the renamed link that was added to `data/links.json`.