### PR TITLE
Change commit message form to imperative form

### DIFF
--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -72,19 +72,19 @@ version: 1.1.0
 
   %ul
     %li
-      %code Added
+      %code Add
       for new features.
     %li
-      %code Changed
+      %code Change
       for changes in existing functionality.
     %li
-      %code Deprecated
+      %code Deprecate
       for soon-to-be removed features.
     %li
-      %code Removed
+      %code Remove
       for now removed features.
     %li
-      %code Fixed
+      %code Fix
       for any bug fixes.
     %li
       %code Security


### PR DESCRIPTION
I noticed the changelog of the repo tend to follow imperative form. Do you agree to change the recommendation to others to the same?