### PR TITLE
Fix a term for zh-TW

### DIFF
--- a/source/zh-TW/1.1.0/index.html.haml
+++ b/source/zh-TW/1.1.0/index.html.haml
@@ -40,7 +40,7 @@ version: 1.1.0
 .good-practices
   %h3#how
     %a.anchor{ href: "#how", aria_hidden: "true" }
-    怎樣寫出高質量的更新日誌？
+    怎樣寫出高品質的更新日誌？
 
   %h4#principles
     %a.anchor{ href: "#principles", aria_hidden: "true" }


### PR DESCRIPTION
## Summary
"高質量" is used mostly in zh-CN, which means "high quality". While in zh-TW it should be "高品質". This PR rectifies this.