### PR TITLE
Add translation coverage analysis tool

### DIFF
--- a/TRANSLATION_COVERAGE.md
+++ b/TRANSLATION_COVERAGE.md
@@ -1,0 +1,216 @@
+# Translation Coverage Tool
+
+A utility for analyzing translation completeness across different language versions of Keep a Changelog.
+
+## Overview
+
+This tool helps maintainers track which sections have been translated in each language and identify missing translations. It analyzes the HAML files across all language directories and versions, comparing them against the English baseline.
+
+## Features
+
+- **Section-by-section analysis** for versions with explicit section IDs (1.0.0+)
+- **Section count comparison** for markdown-based versions (0.3.0)
+- **Multiple output formats**: text (default), JSON, CSV
+- **Filter by version** or specific language
+- **Visual indicators** for translation completeness:
+  - ✓ = 100% complete
+  - ● = 75-99% complete
+  - ◐ = 50-74% complete
+  - ○ = 0-49% complete
+
+## Usage
+
+### Basic Usage
+
+Show coverage for all versions and languages:
+
+```bash
+ruby translation_coverage.rb
+```
+
+### Filter by Version
+
+Analyze a specific version:
+
+```bash
+ruby translation_coverage.rb --version 1.1.0
+ruby translation_coverage.rb --version 1.0.0
+ruby translation_coverage.rb --version 0.3.0
+```
+
+### Filter by Language
+
+Analyze a specific language across all versions:
+
+```bash
+ruby translation_coverage.rb --language fr
+ruby translation_coverage.rb --language es-ES
+ruby translation_coverage.rb --language zh-CN
+```
+
+### Combine Filters
+
+Check a specific language in a specific version:
+
+```bash
+ruby translation_coverage.rb --version 1.1.0 --language pt-BR
+```
+
+### Show Detailed Information
+
+Include section-by-section breakdown and list missing sections:
+
+```bash
+ruby translation_coverage.rb --details
+ruby translation_coverage.rb --version 1.1.0 --details
+```
+
+### Output Formats
+
+#### CSV Format
+
+Perfect for importing into spreadsheets:
+
+```bash
+ruby translation_coverage.rb --format csv > coverage.csv
+```
+
+Output format:
+```csv
+Version,Language,Complete,Missing,Total,Coverage %
+1.1.0,cs,20,0,20,100.0
+1.1.0,da,20,0,20,100.0
+...
+```
+
+#### JSON Format
+
+For programmatic processing:
+
+```bash
+ruby translation_coverage.rb --format json > coverage.json
+```
+
+#### Text Format (Default)
+
+Human-readable report with statistics:
+
+```bash
+ruby translation_coverage.rb --format text
+```
+
+## Understanding the Output
+
+### Version 1.1.0 and 1.0.0
+
+These versions use HAML with explicit section IDs. The tool can identify exactly which sections are missing.
+
+**Sections in 1.1.0 (20 total):**
+- what, why, who, how, principles, types, effort
+- bad-practices, log-diffs, ignoring-deprecations, confusing-dates, inconsistent-changes
+- frequently-asked-questions, standard, filename, github-releases, automatic, yanked, rewrite, contribute
+
+**Sections in 1.0.0 (19 total):**
+Same as 1.1.0 but without `inconsistent-changes`
+
+### Version 0.3.0
+
+This version uses markdown blocks with translated headings, so sections cannot be compared by ID. The tool compares section counts instead:
+
+**Sections in 0.3.0 (14 total):**
+All headings are translated, so coverage is based on whether the translation has the same number of sections as English.
+
+## Example Output
+
+```
+================================================================================
+TRANSLATION COVERAGE REPORT
+Generated: 2026-01-07 18:55:49 UTC
+================================================================================
+
+--------------------------------------------------------------------------------
+VERSION: 1.1.0
+--------------------------------------------------------------------------------
+Baseline (English) has 20 sections
+
+COVERAGE SUMMARY:
+--------------------------------------------------------------------------------
+Language          Complete    Missing     Coverage
+--------------------------------------------------------------------------------
+cs                    20          0       100.0% ✓
+da                    20          0       100.0% ✓
+de                    20          0       100.0% ✓
+...
+--------------------------------------------------------------------------------
+
+STATISTICS:
+  Total translations: 22
+  Complete (100%): 22
+  Partial: 0
+  Average coverage: 100.0%
+```
+
+## Using the Data
+
+### Identifying Translation Work
+
+1. Run the tool for the latest version:
+   ```bash
+   ruby translation_coverage.rb --version 1.1.0
+   ```
+
+2. Look for languages with coverage < 100%
+
+3. Use `--details` to see exactly which sections are missing:
+   ```bash
+   ruby translation_coverage.rb --version 1.1.0 --details
+   ```
+
+### Tracking Progress
+
+Export to CSV and track over time:
+
+```bash
+ruby translation_coverage.rb --format csv > coverage_$(date +%Y%m%d).csv
+```
+
+### Cross-version Comparison
+
+Check all versions to see which languages need updates:
+
+```bash
+ruby translation_coverage.rb --language fr
+```
+
+This shows French translation status across all versions, helping identify if a language needs updates when new sections are added.
+
+## Command-Line Options
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--version VERSION` | `-v` | Filter by specific version (1.1.0, 1.0.0, or 0.3.0) |
+| `--language LANG` | `-l` | Filter by specific language code (e.g., es-ES, fr, de) |
+| `--format FORMAT` | `-f` | Output format: text (default), json, or csv |
+| `--details` | `-d` | Show detailed section-by-section breakdown |
+| `--help` | `-h` | Show help message |
+
+## Requirements
+
+- Ruby (any version with standard library)
+- No external gems required
+
+## Technical Details
+
+The tool works by:
+
+1. **Scanning** the `source/` directory for all language/version combinations
+2. **Extracting** section identifiers from HAML files:
+   - For 1.0.0+: Extracts heading IDs from `%h3#section-id` and `%h4#section-id`
+   - For 0.3.0: Extracts markdown headings from `:markdown` blocks
+3. **Comparing** each language's sections against the English baseline
+4. **Calculating** coverage percentages and identifying missing sections
+5. **Reporting** results in the requested format
+
+## Contributing
+
+If you find issues or have suggestions for improving this tool, please open an issue or pull request.

--- a/translation_coverage.rb
+++ b/translation_coverage.rb
@@ -1,0 +1,315 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'yaml'
+require 'json'
+require 'optparse'
+
+# Translation Coverage Analyzer for Keep a Changelog
+# This utility analyzes which sections are translated in each language version
+# and identifies missing translations compared to the English baseline.
+
+class TranslationCoverageAnalyzer
+  SOURCE_DIR = File.join(__dir__, 'source')
+
+  # Known versions in order (newest first)
+  VERSIONS = ['1.1.0', '1.0.0', '0.3.0'].freeze
+
+  def initialize(options = {})
+    @options = options
+    @version_filter = options[:version]
+    @language_filter = options[:language]
+    @format = options[:format] || 'text'
+    @show_details = options[:details]
+  end
+
+  def analyze
+    results = {
+      analyzed_at: Time.now.utc.strftime('%Y-%m-%d %H:%M:%S UTC'),
+      versions: {}
+    }
+
+    versions_to_check.each do |version|
+      results[:versions][version] = analyze_version(version)
+    end
+
+    results
+  end
+
+  def report
+    results = analyze
+
+    case @format
+    when 'json'
+      print_json_report(results)
+    when 'csv'
+      print_csv_report(results)
+    else
+      print_text_report(results)
+    end
+  end
+
+  private
+
+  def versions_to_check
+    @version_filter ? [@version_filter] : VERSIONS
+  end
+
+  def analyze_version(version)
+    english_sections = extract_sections('en', version)
+
+    return nil if english_sections.nil?
+
+    # Check if this version uses markdown (0.3.0) - sections won't have explicit IDs
+    uses_markdown = version == '0.3.0'
+
+    version_data = {
+      baseline_sections: english_sections,
+      section_count: english_sections.length,
+      uses_markdown: uses_markdown,
+      languages: {}
+    }
+
+    available_languages(version).each do |lang|
+      next if lang == 'en' # Skip English baseline
+      next if @language_filter && lang != @language_filter
+
+      lang_sections = extract_sections(lang, version)
+      next if lang_sections.nil?
+
+      if uses_markdown
+        # For markdown versions, compare by count only (headings are translated)
+        coverage_pct = lang_sections.length == english_sections.length ? 100.0 :
+                      (lang_sections.length.to_f / english_sections.length * 100).round(2)
+
+        version_data[:languages][lang] = {
+          section_count: lang_sections.length,
+          complete_count: lang_sections.length,
+          missing_count: english_sections.length - lang_sections.length,
+          coverage_percentage: coverage_pct
+        }
+      else
+        # For HAML versions with IDs, compare specific sections
+        missing = english_sections - lang_sections
+        extra = lang_sections - english_sections
+        complete = lang_sections & english_sections
+
+        coverage_pct = english_sections.empty? ? 0.0 : (complete.length.to_f / english_sections.length * 100).round(2)
+
+        version_data[:languages][lang] = {
+          sections: lang_sections,
+          complete_count: complete.length,
+          missing_count: missing.length,
+          missing_sections: missing,
+          extra_sections: extra,
+          coverage_percentage: coverage_pct
+        }
+      end
+    end
+
+    version_data
+  end
+
+  def extract_sections(language, version)
+    file_path = File.join(SOURCE_DIR, language, version, 'index.html.haml')
+
+    return nil unless File.exist?(file_path)
+
+    content = File.read(file_path, encoding: 'UTF-8')
+    sections = []
+
+    # Extract h3 and h4 heading IDs (for versions 1.0.0+)
+    # Pattern matches: %h3#section-id, %h4#section-id
+    content.scan(/^\s*%h[34]#([\w-]+)/) do |match|
+      sections << match[0]
+    end
+
+    # For version 0.3.0, extract markdown headings and generate IDs
+    if sections.empty?
+      content.scan(/^\s*###\s+(.+?)$/) do |match|
+        heading = match[0].strip
+        # Convert heading to slug (e.g., "What's a change log?" -> "whats-a-change-log")
+        slug = heading.downcase
+                      .gsub(/[''']/, '')  # Remove apostrophes
+                      .gsub(/[^a-z0-9\s-]/, '')  # Remove non-alphanumeric except spaces and hyphens
+                      .gsub(/\s+/, '-')  # Replace spaces with hyphens
+                      .gsub(/-+/, '-')   # Replace multiple hyphens with single
+                      .gsub(/^-|-$/, '')  # Remove leading/trailing hyphens
+        sections << slug unless slug.empty?
+      end
+    end
+
+    sections
+  end
+
+  def available_languages(version)
+    Dir.glob(File.join(SOURCE_DIR, '*', version))
+       .select { |path| File.directory?(path) }
+       .map { |path| File.basename(File.dirname(path)) }
+       .sort
+  end
+
+  def print_text_report(results)
+    puts "=" * 80
+    puts "TRANSLATION COVERAGE REPORT"
+    puts "Generated: #{results[:analyzed_at]}"
+    puts "=" * 80
+    puts
+
+    results[:versions].each do |version, data|
+      next if data.nil?
+
+      print_version_report(version, data)
+    end
+  end
+
+  def print_version_report(version, data)
+    puts "-" * 80
+    puts "VERSION: #{version}"
+    puts "-" * 80
+    puts "Baseline (English) has #{data[:section_count]} sections"
+
+    if data[:uses_markdown]
+      puts "Note: This version uses markdown format with translated headings."
+      puts "Coverage is based on section count, not specific section IDs."
+    end
+    puts
+
+    if @show_details && !data[:uses_markdown]
+      puts "Sections: " + data[:baseline_sections].join(", ")
+      puts
+    end
+
+    if data[:languages].empty?
+      puts "No translations found for this version."
+      puts
+      return
+    end
+
+    # Summary table
+    puts
+    puts "COVERAGE SUMMARY:"
+    puts "-" * 80
+    printf "%-15s %10s %10s %12s\n", "Language", "Complete", "Missing", "Coverage"
+    puts "-" * 80
+
+    sorted_languages = data[:languages].sort_by { |_, info| -info[:coverage_percentage] }
+
+    sorted_languages.each do |lang, info|
+      status_indicator = case info[:coverage_percentage]
+                        when 100 then "✓"
+                        when 75..99 then "●"
+                        when 50..74 then "◐"
+                        else "○"
+                        end
+
+      printf "%-15s %8d   %8d   %9.1f%% %s\n",
+             lang,
+             info[:complete_count],
+             info[:missing_count],
+             info[:coverage_percentage],
+             status_indicator
+    end
+    puts "-" * 80
+    puts
+
+    # Detailed missing sections (only for non-markdown versions)
+    if @show_details && !data[:uses_markdown]
+      puts "MISSING SECTIONS BY LANGUAGE:"
+      puts "-" * 80
+
+      sorted_languages.each do |lang, info|
+        next if info[:missing_sections].nil? || info[:missing_sections].empty?
+
+        puts "#{lang}:"
+        info[:missing_sections].each do |section|
+          puts "  - #{section}"
+        end
+
+        unless info[:extra_sections].nil? || info[:extra_sections].empty?
+          puts "  Extra sections (not in English):"
+          info[:extra_sections].each do |section|
+            puts "    + #{section}"
+          end
+        end
+        puts
+      end
+      puts
+    end
+
+    # Summary statistics
+    total_translations = data[:languages].count
+
+    if total_translations > 0
+      complete_translations = data[:languages].count { |_, info| info[:coverage_percentage] == 100 }
+      avg_coverage = data[:languages].values.sum { |info| info[:coverage_percentage] } / total_translations
+
+      puts "STATISTICS:"
+      puts "  Total translations: #{total_translations}"
+      puts "  Complete (100%): #{complete_translations}"
+      puts "  Partial: #{total_translations - complete_translations}"
+      puts "  Average coverage: #{avg_coverage.round(2)}%"
+      puts
+    end
+  end
+
+  def print_json_report(results)
+    puts JSON.pretty_generate(results)
+  end
+
+  def print_csv_report(results)
+    puts "Version,Language,Complete,Missing,Total,Coverage %"
+
+    results[:versions].each do |version, data|
+      next if data.nil?
+
+      data[:languages].each do |lang, info|
+        puts [
+          version,
+          lang,
+          info[:complete_count],
+          info[:missing_count],
+          data[:section_count],
+          info[:coverage_percentage]
+        ].join(',')
+      end
+    end
+  end
+end
+
+# CLI Interface
+if __FILE__ == $PROGRAM_NAME
+  options = {}
+
+  OptionParser.new do |opts|
+    opts.banner = "Usage: translation_coverage.rb [options]"
+    opts.separator ""
+    opts.separator "Analyzes translation coverage for Keep a Changelog"
+    opts.separator ""
+    opts.separator "Options:"
+
+    opts.on("-v", "--version VERSION", "Analyze specific version (1.1.0, 1.0.0, or 0.3.0)") do |v|
+      options[:version] = v
+    end
+
+    opts.on("-l", "--language LANGUAGE", "Analyze specific language (e.g., es-ES, fr, de)") do |l|
+      options[:language] = l
+    end
+
+    opts.on("-f", "--format FORMAT", "Output format: text (default), json, or csv") do |f|
+      options[:format] = f
+    end
+
+    opts.on("-d", "--details", "Show detailed section-by-section breakdown") do
+      options[:details] = true
+    end
+
+    opts.on("-h", "--help", "Show this help message") do
+      puts opts
+      exit
+    end
+  end.parse!
+
+  analyzer = TranslationCoverageAnalyzer.new(options)
+  analyzer.report
+end


### PR DESCRIPTION
This commit adds a comprehensive utility to track translation completeness
across all language versions of the Keep a Changelog project.

Features:
- Analyzes section coverage for all versions (1.1.0, 1.0.0, 0.3.0)
- Compares translations against English baseline
- Identifies missing sections and calculates coverage percentages
- Supports multiple output formats (text, JSON, CSV)
- Allows filtering by version and/or language
- Includes detailed section-by-section breakdown option

The tool helps maintainers:
- Determine how much translation work remains
- Identify which sections need translation in each language
- Track translation progress over time
- Export data for analysis and reporting

Includes comprehensive documentation in TRANSLATION_COVERAGE.md