### PR TITLE
Recommend changelog section order by urgency

### DIFF
--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -70,25 +70,34 @@ version: 1.1.0
   %a.anchor{ href: "#types", aria_hidden: "true" }
   %h4#types Types of changes
 
+  %p
+    Each type of change below is a section heading under a version. List sections in
+    the following order of urgency (omit empty sections):
+
   %ul
     %li
-      %code Added
-      for new features.
-    %li
-      %code Changed
-      for changes in existing functionality.
-    %li
-      %code Deprecated
-      for soon-to-be removed features.
+      %code Security
+      for fixes to known security vulnerabilities and advisories.
     %li
       %code Removed
       for now removed features.
     %li
-      %code Fixed
-      for any bug fixes.
+      %code Changed
+      for changes in existing functionality; prefix breaking changes so they stand out
+      (e.g.
+      %code BREAKING:
+      or
+      %strong BREAKING:
+      ).
     %li
-      %code Security
-      in case of vulnerabilities.
+      %code Deprecated
+      for soon-to-be removed features.
+    %li
+      %code Fixed
+      for any bug fixes unrelated to security.
+    %li
+      %code Added
+      for new features.
 
 .effort
 
@@ -146,9 +155,8 @@ version: 1.1.0
     become removals.
 
   %p
-    If you do nothing else, list deprecations, removals, and any
-    breaking changes in your changelog.
-
+    That said, if you do nothing else, list removals and breaking changes
+    in your changelog.
 
   %h4#confusing-dates
     %a.anchor{ href: "#confusing-dates", aria_hidden: "true" }


### PR DESCRIPTION
## Summary
Clarifies **Types of changes** with a recommended section order and omits-empty-sections rule. Updates **Ignoring Deprecations** wording to match upgrade urgency.

## Problem
The spec lists six section types but not their order within a release. Example changelogs (including on keepachangelog.com) often lead with `Added`, so a quick skim can miss security fixes, removals, and breaking changes listed below.

## Proposed order (omit empty sections)
Security → Removed → Changed → Deprecated → Fixed → Added

- **Security** first.
- **Added** last - new features are usually optional for upgrade; removals/breaking changes are not.
- **Fixed** scoped to non-security bugs; security items stay under **Security**.
- **Changed**: prefix breaking entries (e.g. `BREAKING:`) so they stand out.

## Ignoring Deprecations
Reword closing line: minimum bar is **removals and breaking changes**; deprecations remain important for the two-step upgrade path described above.

## Semver
I’m not changing the spec version in this PR. If this guidance is **normative**, I’d expect **2.0.0**; if **recommended**, **1.2.0**. Happy to adjust wording or target a new spec page.

## Commit message
Readers skim changelogs to learn what affects them most. The spec listed change types but gave no guidance on section order, so projects often buried urgent items (security fixes, removals) below additions and minor fixes.

Introduce a recommended section order under each version, from most to least urgent: Security, Removed, Changed, Deprecated, Fixed, Added.

Clarify that Fixed is for non-security bug fixes, to distinguish it from the Security section now that everything is ordered by urgency.

Document how to mark breaking changes within Changed (e.g. BREAKING: in code or bold).

In Ignoring Deprecations, separate the ideal upgrade path (list deprecations so users can migrate in steps) from the absolute minimum for negligent maintainers. "That said, if you do nothing else" sets that floor at removals and breaking changes - what breaks today - without repeating deprecations or diluting the paragraph above.