### PR TITLE
Add a manual GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy
+
+# Manual deploy. Builds the production site and publishes it to the gh-pages
+# branch that GitHub Pages serves at keepachangelog.com — the same thing
+# `rake deploy` does locally, but reproducibly from CI. Trigger it from the
+# Actions tab ("Run workflow"); you can pick which branch to build from.
+#
+# Note: the build uses the default config, so $last_version (currently 1.1.0)
+# decides the published "latest" version. 2.0 stays behind ?preview=v2 until you
+# flip that flag in config.rb.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write # push the built site to the gh-pages branch
+
+# Never run two deploys at once; don't cancel an in-progress publish.
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Build site
+        run: bundle exec middleman build
+
+      - name: Publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages
+          # Keep the custom domain on the published branch.
+          cname: keepachangelog.com
+          # Replace gh-pages with a single fresh commit each deploy (built output
+          # has no history worth keeping); adds .nojekyll so Pages serves the
+          # pre-built files as-is.
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          full_commit_message: 'Deploy ${{ github.sha }}'


### PR DESCRIPTION
Adds a **manually-triggered** deploy so publishing the site is reproducible from CI instead of relying on a local `rake deploy`.

## What it does
- `workflow_dispatch` only — run it from the **Actions tab** ("Run workflow"); you can pick which branch to build from.
- Builds the **production** site (`bundle exec middleman build` — minified, asset-hashed, gzipped, analytics on).
- Publishes `./build` to the **`gh-pages`** branch (which Pages serves at keepachangelog.com) via `peaceiris/actions-gh-pages`, preserving the `CNAME`, adding `.nojekyll`, and replacing `gh-pages` with one clean commit.
- `concurrency` prevents overlapping deploys.

It's the CI equivalent of `rake deploy` (which stays available as a local fallback).

## Notes
- Uses the **default build config**, so `$last_version` (currently `1.1.0`) decides the published "latest" version — 2.0 stays behind `?preview=v2` until that flag is flipped in `config.rb`.
- Pages stays on its current `gh-pages`/legacy source; no Pages settings change required.
- One third-party action (`peaceiris/actions-gh-pages@v4`); can be swapped for a plain `git` push if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)