### PR TITLE
Soften the hero pattern gradient

### DIFF
--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -395,8 +395,9 @@
 /* ----------------------------------------------------------------- content */
 @layer content {
   /* Hero band — the brand identity lives here. Light topographic contour lines
-     over the deep ocre base; a top scrim (solid → transparent) keeps the title
-     and tagline legible while the pattern shows around and below them. */
+     over the deep ocre base. A gentle scrim keeps the pattern subtle throughout:
+     solid behind the title for legibility, faintly revealed through the middle,
+     then easing back out so the pattern is least opaque toward the bottom. */
   .hero {
     background-color: var(--hero-bg);
     /* PNG fallback first, then WebP via image-set where supported (about half the
@@ -405,14 +406,14 @@
     background-image:
       linear-gradient(to bottom,
         var(--hero-bg) 0,
-        var(--hero-bg) 34%,
-        color-mix(in srgb, var(--hero-bg) 45%, transparent) 100%),
+        color-mix(in srgb, var(--hero-bg) 84%, transparent) 35%,
+        color-mix(in srgb, var(--hero-bg) 92%, transparent) 100%),
       url("../images/hero-topo@2x.png");
     background-image:
       linear-gradient(to bottom,
         var(--hero-bg) 0,
-        var(--hero-bg) 34%,
-        color-mix(in srgb, var(--hero-bg) 45%, transparent) 100%),
+        color-mix(in srgb, var(--hero-bg) 84%, transparent) 35%,
+        color-mix(in srgb, var(--hero-bg) 92%, transparent) 100%),
       image-set(
         url("../images/hero-topo@2x.webp") type("image/webp"),
         url("../images/hero-topo@2x.png") type("image/png"));


### PR DESCRIPTION
## Preview

| Before (`main`) | After (this PR) |
|---|---|
| ![Before](https://raw.githubusercontent.com/olivierlacan/keep-a-changelog/hero-gradient-assets/pr-preview/hero-before.png) | ![After](https://raw.githubusercontent.com/olivierlacan/keep-a-changelog/hero-gradient-assets/pr-preview/hero-after.png) |

The contour pattern was boldest along the bottom edge before; now it's faint through the middle and fades out toward the bottom.

## What

Softens the topographic pattern in the hero. The old scrim kept the title area solid, then *increased* the pattern's opacity toward the bottom — so the contour lines were at their boldest along the bottom edge.

The new scrim keeps the pattern subtle throughout: solid behind the title for legibility, faintly revealed through the middle, then eased back out so the pattern is **least opaque toward the bottom**.

## Change

Just the `.hero` background gradient in `source/assets/stylesheets/v2.css` (both the PNG-fallback and WebP `image-set` declarations):

```diff
-      var(--hero-bg) 0,
-      var(--hero-bg) 34%,
-      color-mix(in srgb, var(--hero-bg) 45%, transparent) 100%
+      var(--hero-bg) 0,
+      color-mix(in srgb, var(--hero-bg) 84%, transparent) 35%,
+      color-mix(in srgb, var(--hero-bg) 92%, transparent) 100%
```

Peak pattern visibility drops from ~55% (at the bottom) to ~16% (mid), fading to ~8% at the bottom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
