### PR TITLE
Create every missing release (follow-up to #709)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ name: Release from changelog
 #              plan found changes.
 #
 # Modes:
-#   create (default): create a release for the latest dated version if missing.
+#   create (default): create a release for every dated version that's missing one.
 #   sync (manual opt-in): also reconcile the body of every existing release
 #                         against its changelog entry (e.g. a translation added
 #                         to an already-released version).

--- a/test/changelog_release_test.rb
+++ b/test/changelog_release_test.rb
@@ -159,29 +159,48 @@ class ChangelogReleaseCreateTest < Minitest::Test
     ChangelogRelease::Runner.new(@entries, github: github, logger: @log)
   end
 
-  def test_creates_release_and_tag_when_missing
+  def test_creates_every_missing_release_oldest_first
     github = FakeGitHub.new
-    assert runner(github).create_latest(sha: "abc123")
+    created = runner(github).create_missing(sha: "abc123")
 
-    assert_equal ["v1.1.0"], github.created.map { |c| c[:tag] }
-    assert_equal "1.1.0", github.created.first[:title]
-    assert_includes github.created.first[:notes], "Italian translation."
+    # Fixture has v1.1.0, v1.0.0, v0.0.5 — all missing, created oldest first.
+    assert_equal ["v0.0.5", "v1.0.0", "v1.1.0"], created
+    assert_equal ["v0.0.5", "v1.0.0", "v1.1.0"], github.created.map { |c| c[:tag] }
     assert_includes github.tags, "v1.1.0"
   end
 
-  def test_does_nothing_when_release_exists
-    github = FakeGitHub.new(releases: {"v1.1.0" => "whatever"})
-    refute runner(github).create_latest(sha: "abc123")
+  def test_creates_only_the_missing_ones
+    github = FakeGitHub.new(releases: {"v1.0.0" => "whatever"})
+    created = runner(github).create_missing(sha: "abc123")
 
+    assert_equal ["v0.0.5", "v1.1.0"], created # v1.0.0 already existed
+    refute_includes created, "v1.0.0"
+  end
+
+  def test_create_uses_yanked_title
+    github = FakeGitHub.new
+    runner(github).create_missing(sha: "abc123")
+
+    yanked = github.created.find { |c| c[:tag] == "v0.0.5" }
+    assert_equal "0.0.5 [YANKED]", yanked[:title]
+  end
+
+  def test_does_nothing_when_all_releases_exist
+    existing = {"v1.1.0" => "a", "v1.0.0" => "b", "v0.0.5" => "c"}
+    github = FakeGitHub.new(releases: existing)
+    created = runner(github).create_missing(sha: "abc123")
+
+    assert_empty created
     assert_empty github.created
   end
 
   def test_does_not_recreate_existing_tag
-    github = FakeGitHub.new(tags: ["v1.1.0"])
-    runner(github).create_latest(sha: "abc123")
+    github = FakeGitHub.new(tags: ["v1.1.0", "v1.0.0", "v0.0.5"])
+    runner(github).create_missing(sha: "abc123")
 
-    assert_equal ["v1.1.0"], github.tags # not duplicated
-    assert_equal ["v1.1.0"], github.created.map { |c| c[:tag] }
+    # Tags already present, so none are re-created; releases still are.
+    assert_equal ["v1.1.0", "v1.0.0", "v0.0.5"], github.tags
+    assert_equal ["v0.0.5", "v1.0.0", "v1.1.0"], github.created.map { |c| c[:tag] }
   end
 end
 
@@ -280,31 +299,42 @@ class ChangelogReleasePlanTest < Minitest::Test
     ChangelogRelease::Runner.new(@entries, github: github, logger: @log)
   end
 
-  def test_create_plan_marks_missing_latest_as_create
+  def test_create_plan_marks_every_missing_version_as_create
     items = runner(FakeGitHub.new).plan(mode: :create)
 
-    assert_equal 1, items.length # create mode only considers the latest
-    assert_equal :create, items.first.action
+    # Every version in the changelog is planned, all missing → all create.
+    assert_equal %w[v1.1.0 v1.0.0 v0.0.5], items.map(&:tag)
+    assert(items.all? { |item| item.action == :create })
     assert_includes items.first.details, "Italian translation."
     assert ChangelogRelease.changes?(items)
   end
 
-  def test_create_plan_marks_existing_matching_latest_as_unchanged
+  def test_create_plan_leaves_existing_releases_unchanged
     github = FakeGitHub.new(releases: {"v1.1.0" => @entries.first.notes})
     items = runner(github).plan(mode: :create)
+    by_tag = items.to_h { |item| [item.tag, item] }
 
-    assert_equal :unchanged, items.first.action
+    assert_equal :unchanged, by_tag["v1.1.0"].action # exists, not reconciled in create
+    assert_equal :create, by_tag["v1.0.0"].action # still missing → create
+    assert ChangelogRelease.changes?(items)
+  end
+
+  def test_create_plan_with_all_releases_present_has_no_changes
+    existing = @entries.to_h { |e| [e.tag, e.notes] }
+    items = runner(FakeGitHub.new(releases: existing)).plan(mode: :create)
+
+    assert(items.all? { |item| item.action == :unchanged })
     refute ChangelogRelease.changes?(items)
   end
 
-  def test_sync_plan_covers_every_version_with_diff_for_drift
+  def test_sync_plan_creates_missing_and_diffs_drift
     github = FakeGitHub.new(releases: {"v1.1.0" => "### Added\n"})
     items = runner(github).plan(mode: :sync)
 
     by_tag = items.to_h { |item| [item.tag, item] }
     assert_equal :update, by_tag["v1.1.0"].action
     assert_includes by_tag["v1.1.0"].details, "+- Indonesian translation."
-    assert_equal :skip, by_tag["v1.0.0"].action # exists in changelog, no release yet
+    assert_equal :create, by_tag["v1.0.0"].action # missing → create (no longer skipped)
     assert ChangelogRelease.changes?(items)
   end
 
@@ -319,8 +349,8 @@ class ChangelogReleasePlanTest < Minitest::Test
   end
 
   def test_format_plan_reports_when_nothing_to_do
-    github = FakeGitHub.new(releases: {"v1.1.0" => @entries.first.notes})
-    items = runner(github).plan(mode: :create)
+    existing = @entries.to_h { |e| [e.tag, e.notes] }
+    items = runner(FakeGitHub.new(releases: existing)).plan(mode: :create)
     markdown = ChangelogRelease.format_plan(items, sync: false)
 
     assert_includes markdown, "Nothing to create or update"

--- a/tools/changelog_release.rb
+++ b/tools/changelog_release.rb
@@ -8,11 +8,11 @@
 # isolation — see test/changelog_release_test.rb) and a command-line tool:
 #
 #   ruby tools/changelog_release.rb create [--dry-run]
-#       Create a release for the latest dated version if one doesn't exist yet.
-#       Idempotent: does nothing if the release is already there.
+#       Create a release for every dated version that doesn't have one yet.
+#       Idempotent: skips versions whose release already exists.
 #
 #   ruby tools/changelog_release.rb sync [--dry-run]
-#       Create-if-missing for the latest version, then reconcile the body of
+#       Create every missing release (as above), then reconcile the body of
 #       *every* existing release against its changelog entry, updating any that
 #       have drifted. This is how a translation added to an already-released
 #       version (same minor, or a patch) gets pushed up to its published release.
@@ -38,16 +38,15 @@ module ChangelogRelease
     end
   end
 
-  # One line of the dry-run plan. +action+ is :create, :update, :unchanged, or
-  # :skip; +details+ holds the new notes (:create) or a unified diff (:update).
+  # One line of the dry-run plan. +action+ is :create, :update, or :unchanged;
+  # +details+ holds the new notes (:create) or a unified diff (:update).
   PlanItem = Struct.new(:tag, :date, :action, :details, keyword_init: true)
 
   # Human-readable labels for each plan action, used in the summary table.
   ACTION_LABELS = {
     create: "🆕 create",
     update: "✏️ update",
-    unchanged: "✓ unchanged",
-    skip: "⏭ skip (no release yet)"
+    unchanged: "✓ unchanged"
   }.freeze
 
   # A dated version heading, e.g. "## [1.1.0] - 2019-02-15" — skips
@@ -277,25 +276,28 @@ module ChangelogRelease
       @logger = logger
     end
 
-    # Create a release for the latest version if it doesn't exist yet. Returns
-    # true if it created one, false if the release was already there.
-    def create_latest(sha:)
-      entry = @entries.first
-      if @github.release_exists?(entry.tag)
-        log "#{entry.tag} already exists — nothing to create."
-        return false
-      end
+    # Create a release for every dated version that doesn't have one yet, oldest
+    # first so the timeline is built in order. Existing releases are left alone.
+    # Tags are created (dated to the changelog entry) only when missing. Returns
+    # the tags it created.
+    def create_missing(sha:)
+      @entries.reverse_each.each_with_object([]) do |entry, created|
+        if @github.release_exists?(entry.tag)
+          log "#{entry.tag} already exists — skipping."
+          next
+        end
 
-      log "Creating release #{entry.tag} (version #{entry.version}, dated #{entry.date})…"
-      @github.create_tag(entry.tag, message: entry.version, date: entry.date, sha: sha) unless @github.tag_exists?(entry.tag)
-      @github.create_release(tag: entry.tag, title: entry.title, notes: entry.notes)
-      true
+        log "Creating release #{entry.tag} (version #{entry.version}, dated #{entry.date})…"
+        @github.create_tag(entry.tag, message: entry.version, date: entry.date, sha: sha) unless @github.tag_exists?(entry.tag)
+        @github.create_release(tag: entry.tag, title: entry.title, notes: entry.notes)
+        created << entry.tag
+      end
     end
 
     # Update the body of every existing release whose notes have drifted from the
-    # changelog. Releases that don't exist yet are skipped (create_latest owns the
-    # newest one); releases that already match are left untouched. Returns the
-    # tags it updated.
+    # changelog. Releases that don't exist yet are skipped (create_missing makes
+    # those); releases that already match are left untouched. Returns the tags it
+    # updated.
     def sync_all
       @entries.each_with_object([]) do |entry, updated|
         unless @github.release_exists?(entry.tag)
@@ -313,30 +315,30 @@ module ChangelogRelease
       end
     end
 
-    # Compute, without making any changes, what create/sync would do. +mode+ is
-    # :create (latest only) or :sync (latest + reconcile every existing release).
-    # Returns an array of PlanItem.
+    # Compute, without making any changes, what create/sync would do. Every
+    # missing release is planned as a create. +mode+ :sync additionally reconciles
+    # existing releases (so they show as :update or :unchanged); :create leaves
+    # existing releases untouched (always :unchanged). Returns an array of PlanItem.
     def plan(mode:)
-      items = [plan_for(@entries.first, create_if_missing: true)]
-      @entries.drop(1).each { |entry| items << plan_for(entry, create_if_missing: false) } if mode == :sync
-      items
+      reconcile = mode == :sync
+      @entries.map { |entry| plan_for(entry, reconcile: reconcile) }
     end
 
     private
 
-    def plan_for(entry, create_if_missing:)
-      if @github.release_exists?(entry.tag)
-        current = @github.release_body(entry.tag)
-        if ChangelogRelease.normalize(current) == ChangelogRelease.normalize(entry.notes)
-          PlanItem.new(tag: entry.tag, date: entry.date, action: :unchanged)
-        else
-          PlanItem.new(tag: entry.tag, date: entry.date, action: :update,
-            details: ChangelogRelease.unified_diff(current, entry.notes))
-        end
-      elsif create_if_missing
-        PlanItem.new(tag: entry.tag, date: entry.date, action: :create, details: entry.notes)
+    def plan_for(entry, reconcile:)
+      unless @github.release_exists?(entry.tag)
+        return PlanItem.new(tag: entry.tag, date: entry.date, action: :create, details: entry.notes)
+      end
+
+      return PlanItem.new(tag: entry.tag, date: entry.date, action: :unchanged) unless reconcile
+
+      current = @github.release_body(entry.tag)
+      if ChangelogRelease.normalize(current) == ChangelogRelease.normalize(entry.notes)
+        PlanItem.new(tag: entry.tag, date: entry.date, action: :unchanged)
       else
-        PlanItem.new(tag: entry.tag, date: entry.date, action: :skip)
+        PlanItem.new(tag: entry.tag, date: entry.date, action: :update,
+          details: ChangelogRelease.unified_diff(current, entry.notes))
       end
     end
 
@@ -370,7 +372,7 @@ if $PROGRAM_NAME == __FILE__
       File.open(output, "a") { |file| file.puts "changes=#{ChangelogRelease.changes?(items)}" }
     end
   else
-    runner.create_latest(sha: ENV.fetch("GITHUB_SHA"))
+    runner.create_missing(sha: ENV.fetch("GITHUB_SHA"))
     runner.sync_all if mode == :sync
   end
 end


### PR DESCRIPTION
## What

Brings the **"create any missing release"** change to `main`. It was developed on the #709 branch but landed *after* #709 was squash-merged, so it never made it in — `main` currently only creates the **latest** release (`create_latest`), not historical gaps like the freshly-tagged `v1.1.2`.

This cherry-picks the missing commit cleanly onto current `main`.

## Why it matters

The release workflow on `main` would only ever create `v2.0.0`. With this, `create` walks **every** dated changelog version oldest-first and creates a release for any that lacks one (e.g. `v1.1.2`), leaving existing releases alone. `sync` runs `create_missing` first, then reconciles bodies.

## Change

- `create_latest` → **`create_missing`** (all missing versions, oldest first; tags created only when absent, dated to the changelog entry).
- Plan lists every version (`:create` / `:update` / `:unchanged`); the `:skip` action is gone.
- Workflow comment updated.

## Verified

- 33 tests / 90 assertions pass (`bin/rake test`).
- `standardrb` clean; workflow YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
