### PR TITLE
Justify 2.0.0 as a breaking edition and mark the breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2026-06-07
 
-2.0.0 is the first major revision of Keep a Changelog. The format itself is
-unchanged: the six change types, `YYYY-MM-DD` dates, and the `Unreleased` and
-`[YANKED]` markers all stay valid, so nothing you have already written breaks.
-What changes is the guidance around it, alongside a restructured page, a new
-tagline, and a redesigned, accessible site.
+2.0.0 is the first major revision of Keep a Changelog. It breaks the guidance,
+not the format: the six change types, `YYYY-MM-DD` dates, and the `Unreleased`
+and `[YANKED]` markers are all unchanged, so your existing changelog stays valid.
+What breaks is the surface around it. The page is restructured so some older
+section links no longer resolve, the recommended guidance has shifted, and
+existing translations are out of date until they catch up. The breaking changes
+are marked below.
 
 ### Added
 
@@ -35,10 +37,11 @@ tagline, and a redesigned, accessible site.
 
 ### Changed
 
-- New tagline: "Clearly document the evolution of your projects." (replacing
-  "Don't let your friends dump git logs into changelogs," kept on earlier versions).
-- Restructured the page from a flat FAQ into integrated guidance, in a plainer,
-  less first-person voice.
+- **Breaking:** Retired the tagline "Don't let your friends dump git logs into
+  changelogs" for "Clearly document the evolution of your projects." Earlier
+  versions keep the original.
+- **Breaking:** Restructured the page from a flat FAQ into integrated guidance,
+  in a plainer, less first-person voice. Some older section links no longer resolve.
 - Reframed the "GitHub Releases" answer as "Is a changelog the same as release
   notes?", broadened beyond GitHub to any host.
 - Set page titles and descriptions from frontmatter, and fixed OpenGraph metadata
@@ -48,8 +51,8 @@ tagline, and a redesigned, accessible site.
 
 - Outdated specifics (the Vandamme gem reference and a GitHub-Releases
   discoverability note) in favor of more general guidance.
-- The FAQ scaffolding and most first-person framing; the podcast note now lives
-  in the References section.
+- **Breaking:** The FAQ scaffolding and most first-person framing, whose section
+  anchors no longer resolve; the podcast note now lives in the References section.
 
 ## [1.1.2] - 2024-09-27
 


### PR DESCRIPTION
## What

Resolves the SemVer contradiction in the 2.0.0 entry. It opened with *"nothing you have already written breaks"* while shipping a major bump — directly at odds with the page's own *"this project adheres to Semantic Versioning."*

Per the decision to stand behind 2.0.0 as a **deliberate breaking edition**, this reframes the entry honestly and marks the real breaks using the project's *own* `**Breaking:**` convention (which 2.0 introduces, line 84 of the guidance: marker in place, within its type, not a separate section).

## Changes

- **Summary reframed:** "It breaks the guidance, not the format." The format (six types, dates, `Unreleased`/`[YANKED]`) stays compatible, so existing changelogs remain valid; what breaks is the surface — restructured page (dead section links), shifted guidance, and translations now stale until they catch up.
- **`**Breaking:**` markers** on the three genuine breaks:
  - *Changed:* retired tagline; restructure (older section links no longer resolve).
  - *Removed:* FAQ scaffolding whose section anchors no longer resolve.

## Nice side effect

`CHANGELOG.md` is the example rendered in the hero, so our own changelog now **demonstrates the `**Breaking:**` marker** the 2.0 guidance teaches. Dogfooding.

No em dashes; no trailing whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
