### PR TITLE
Desaturate the hero orange

### DIFF
--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -31,12 +31,14 @@
     --rule: light-dark(oklch(0.88 0.015 70), oklch(0.36 0.02 30));
     --code-bg: light-dark(oklch(0.955 0.02 75), oklch(0.27 0.02 30));
     --code-text: light-dark(var(--bark), var(--sand));
-    /* Deeper ocre for the hero so light text clears 4.5:1. Light topographic
-       contour lines sit over it; a scrim keeps the title legible. */
-    /* A darkened orange (not the bright Fire Orange, which fails contrast under
-       cream text). Hue ~42 keeps it orange instead of the brick red the old
-       hue-33 darkening produced. Cream text clears 4.5:1 (light) / 5.8:1 (dark). */
-    --hero-bg: light-dark(oklch(0.53 0.19 42), oklch(0.49 0.18 42));
+    /* Muted orange for the hero. Light topographic contour lines sit over it;
+       a scrim keeps the title legible. */
+    /* Slightly lower chroma than the Fire Orange (0.15 vs ~0.19) for a softer,
+       less saturated wash, while lightness stays low enough that cream text keeps
+       clearing 4.5:1. Going lighter (toward a true pastel) isn't possible with
+       cream text; it would need dark text. Hue ~42 keeps it orange, not brick
+       red. Cream text clears 4.87:1 (light) / 5.78:1 (dark). */
+    --hero-bg: light-dark(oklch(0.53 0.15 42), oklch(0.49 0.15 42));
     --hero-text: var(--sand);
     --accent: light-dark(var(--ocre), var(--gold));
     --focus: light-dark(oklch(0.55 0.18 41), var(--gold));


### PR DESCRIPTION
## Preview

| Before (`main`, chroma 0.19) | After (this PR, chroma 0.15) |
|---|---|
| ![Before](https://raw.githubusercontent.com/olivierlacan/keep-a-changelog/hero-desaturate-assets/pr-preview/hero-before.png) | ![After](https://raw.githubusercontent.com/olivierlacan/keep-a-changelog/hero-desaturate-assets/pr-preview/hero-after.png) |

## What

Softens the hero orange by lowering its chroma from ~0.19 to **0.15** (hue 42, lightness unchanged) — a less saturated, less "fiery" wash, while keeping the cream text and the rest of the design.

This is half the desaturation of a first pass at 0.11, which read as too washed-out.

## Why not a true pastel

A genuinely pastel (light) orange is impossible while the hero text stays cream: light text caps how light the background can go before failing 4.5:1. A pastel would require flipping the hero text to dark — a larger redesign we opted not to do here. So this stays a deep orange, just muted.

## Accessibility

- Cream text on the new hero: **4.87:1** (light) / **5.78:1** (dark) — clears WCAG AA (4.5:1) with margin. (Computed via OKLCH→sRGB→WCAG luminance.)
- axe gate passes **8/8** (light + dark × desktop/mobile/pinned-header/picker-open).

Single-line change to the `--hero-bg` token in `source/assets/stylesheets/v2.css`. Rebased on current `main` (includes #714's hero padding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
