### PR TITLE
Redirect patch-version URLs to their minor spec page (fixes #690)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -174,6 +174,21 @@ $languages.each do |language|
   redirect "#{code}/index.html", to: "#{code}/#{$published_version_for.call(code)}/index.html"
 end
 
+# Patch releases of this project (e.g. 1.1.1) ship fixes to the site and tooling
+# without changing the changelog *specification*, so they never get their own
+# spec page — the spec stays at the x.y.0 minor (1.1.0). But those patch versions
+# do appear in our own example changelog on the homepage, so visitors spot one
+# and try /en/1.1.1/, which would otherwise 404 (issue #690). Redirect each such
+# patch URL to the minor spec page it belongs to, when that page exists.
+File.read("CHANGELOG.md").scan(/^##\s*\[(\d+)\.(\d+)\.(\d+)\]/).each do |major, minor, patch|
+  next if patch == "0" # minor/major releases already have their own spec page
+  spec_version = "#{major}.#{minor}.0"
+  patch_version = "#{major}.#{minor}.#{patch}"
+  next unless File.directory?("source/en/#{spec_version}")
+  next if File.directory?("source/en/#{patch_version}") # never shadow a real spec page
+  redirect "en/#{patch_version}/index.html", to: "en/#{spec_version}/index.html"
+end
+
 # ----- Assets ----- #
 
 set :css_dir, "assets/stylesheets"


### PR DESCRIPTION
## Problem

Issue #690 reports that `https://keepachangelog.com/en/1.1.1/` returns a 404, even though `1.1.1` "was released a long time ago."

### Root cause

`1.1.1` (and `1.1.2`) are **patch releases of this project/website** — they ship fixes to the site and tooling but do **not** introduce a new version of the changelog *specification*. The spec versions are `0.3.0`, `1.0.0`, `1.1.0` (and the in-progress `2.0.0`), so only those have pages under `source/en/`.

The confusion is understandable: the homepage shows *our own* `CHANGELOG.md` as the example, which contains a `## [1.1.1] - 2023-03-05` heading. A visitor spots `1.1.1` there, navigates to `/en/1.1.1/`, and hits a 404.

## Fix

Generate a redirect from each patch-version URL to the `x.y.0` minor spec page it belongs to. The list of patch versions is derived from the `## [x.y.z]` headings in `CHANGELOG.md`, so it stays correct as new patch releases are cut — no hardcoding.

Guards keep it safe:
- only emitted when the target minor page (e.g. `source/en/1.1.0`) actually exists;
- a real spec directory is never shadowed by a redirect.

With this change, `/en/1.1.1/` serves a canonical redirect to `/en/1.1.0/`:

```html
<link rel="canonical" href="/en/1.1.0/"/>
<meta http-equiv=refresh content="0; url=/en/1.1.0/"/>
<meta name="robots" content="noindex,follow"/>
```

## Verification

Built locally with `middleman build`:
- `build/en/1.1.1/index.html` is created and redirects to `/en/1.1.0/`;
- `build/en/1.0.0`, `build/en/1.1.0`, and `build/en/2.0.0` spec pages are unchanged.

## Note on the follow-up comments

Later comments on the issue raise a separate concern: `/en/` still redirects to `1.1.0` rather than the newer `2.0.0`. That is **intentional** and gated behind the `KAC_PREVIEW_V2` flag per the comments in `config.rb` ("2.0.0 ... stays unpublished until release"). Promoting `2.0.0` to latest is an editorial call for the maintainer (flip `$last_version = "2.0.0"`), so it's deliberately left out of this PR, which focuses on the reported 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWRvJB8gQYDiFnhgthE8ts)_