### PR TITLE
Clarify date format guidance and note heading anchors in 2.0

### DIFF
--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -97,7 +97,7 @@ Keep an `Unreleased` section at the top to collect upcoming changes. It shows re
 
 A version starts with its number and date, for example `## [1.0.0] - 2017-07-17`. Use the `YYYY-MM-DD` format. It orders from the largest unit to the smallest, avoids the confusion of regional date formats, and is an [ISO standard][iso-8601]. A written-out date like `July 17, 2017` is clear enough, but it is written differently around the world — `17 July 2017`, with or without an ordinal — and an all-numeric form is genuinely ambiguous: `02-03-2017` is February in some countries and March in others. None of these will break a changelog, but `YYYY-MM-DD` reads the same everywhere, which is why it is the form to prefer.
 
-A changelog is written in [Markdown][markdown]: a plain-text format that stays readable on its own and renders as formatted HTML on any host. That is why a version is a `##` heading and the square brackets around `[1.0.0]` make it a reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
+A changelog is written in [Markdown][markdown]: a plain-text format that stays readable on its own and renders as formatted HTML on any host. That is why each version sits under a `##` second-level heading — the single `#` is reserved for the `# Changelog` title at the top of the file — and the square brackets around `[1.0.0]` make it a reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
 
 ```
 [Unreleased]: https://github.com/your/project/compare/v1.1.0...HEAD
@@ -254,7 +254,7 @@ Its reach extends past software, too. Peer-reviewed research on software version
 [versioning-schemes]: https://en.wikipedia.org/wiki/Software_versioning#Schemes
 [semver]: https://semver.org/
 [iso-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
-[markdown]: https://www.markdownguide.org/
+[markdown]: https://commonmark.org/help/
 [calver]: https://calver.org/
 [git]: https://en.wikipedia.org/wiki/Git
 [vcs]: https://en.wikipedia.org/wiki/Distributed_version_control

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -95,7 +95,7 @@ A short upgrade note can sit in the entry itself, such as "rename the `color` op
 
 Keep an `Unreleased` section at the top to collect upcoming changes. It shows readers what to expect, and at release time you move its contents into a new version. Starting on a project that has no changelog? Begin here, recording notable changes from now on. Reconstructing past releases from your version history is also worthwhile if you want a fuller record; either is fine.
 
-A version starts with its number and date, for example `## [1.0.0] - 2017-07-17`. Use the `YYYY-MM-DD` format. It orders from the largest unit to the smallest, avoids the confusion of regional date formats, and is an [ISO standard][iso-8601].
+A version starts with its number and date, for example `## [1.0.0] - 2017-07-17`. Use the `YYYY-MM-DD` format. It orders from the largest unit to the smallest, avoids the confusion of regional date formats, and is an [ISO standard][iso-8601]. A written-out date like `July 17, 2017` is clear enough, but it is written differently around the world — `17 July 2017`, with or without an ordinal — and an all-numeric form is genuinely ambiguous: `02-03-2017` is February in some countries and March in others. None of these will break a changelog, but `YYYY-MM-DD` reads the same everywhere, which is why it is the form to prefer.
 
 The square brackets around `[1.0.0]` make it a Markdown reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
 
@@ -105,7 +105,7 @@ The square brackets around `[1.0.0]` make it a Markdown reference link. Resolve 
 [1.0.0]: https://github.com/your/project/releases/tag/v1.0.0
 ```
 
-`[Unreleased]` compares the latest tag to `HEAD` (the current state of your code), so it always shows what has accrued since the last release, and the oldest version links to its tag, since there is nothing earlier to compare it with. Now every version is tied to its tag and links to the exact diff of what changed: the same association a hosted release page makes for you, kept in a file you own instead of a host's database. Any host exposes tag and comparison URLs, so the pattern works wherever your code lives, and the link stays out of the heading, so the changelog still reads cleanly.
+`[Unreleased]` compares the latest tag to `HEAD` (the current state of your code), so it always shows what has accrued since the last release, and the oldest version links to its tag, since there is nothing earlier to compare it with. Now every version is tied to its tag and links to the exact diff of what changed: the same association a hosted release page makes for you, kept in a file you own instead of a host's database. Any host exposes tag and comparison URLs, so the pattern works wherever your code lives, and the link stays out of the heading, so the changelog still reads cleanly — and since hosts render each `##` heading as an HTML anchor, a clean heading is also a clean, direct link to that version.
 
 When you cut a release, rename `Unreleased` to the new version in both the heading and its link, then add a fresh, empty `Unreleased` section pointing at `HEAD`.
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -97,7 +97,7 @@ Keep an `Unreleased` section at the top to collect upcoming changes. It shows re
 
 A version starts with its number and date, for example `## [1.0.0] - 2017-07-17`. Use the `YYYY-MM-DD` format. It orders from the largest unit to the smallest, avoids the confusion of regional date formats, and is an [ISO standard][iso-8601]. A written-out date like `July 17, 2017` is clear enough, but it is written differently around the world — `17 July 2017`, with or without an ordinal — and an all-numeric form is genuinely ambiguous: `02-03-2017` is February in some countries and March in others. None of these will break a changelog, but `YYYY-MM-DD` reads the same everywhere, which is why it is the form to prefer.
 
-The square brackets around `[1.0.0]` make it a Markdown reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
+A changelog is written in [Markdown][markdown]: a plain-text format that stays readable on its own and renders as formatted HTML on any host. That is why a version is a `##` heading and the square brackets around `[1.0.0]` make it a reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
 
 ```
 [Unreleased]: https://github.com/your/project/compare/v1.1.0...HEAD
@@ -254,6 +254,7 @@ Its reach extends past software, too. Peer-reviewed research on software version
 [versioning-schemes]: https://en.wikipedia.org/wiki/Software_versioning#Schemes
 [semver]: https://semver.org/
 [iso-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
+[markdown]: https://www.markdownguide.org/
 [calver]: https://calver.org/
 [git]: https://en.wikipedia.org/wiki/Git
 [vcs]: https://en.wikipedia.org/wiki/Distributed_version_control

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -97,7 +97,7 @@ Keep an `Unreleased` section at the top to collect upcoming changes. It shows re
 
 A version starts with its number and date, for example `## [1.0.0] - 2017-07-17`. Use the `YYYY-MM-DD` format. It orders from the largest unit to the smallest, avoids the confusion of regional date formats, and is an [ISO standard][iso-8601]. A written-out date like `July 17, 2017` is clear enough, but it is written differently around the world — `17 July 2017`, with or without an ordinal — and an all-numeric form is genuinely ambiguous: `02-03-2017` is February in some countries and March in others. None of these will break a changelog, but `YYYY-MM-DD` reads the same everywhere, which is why it is the form to prefer.
 
-A changelog is written in [Markdown][markdown]: a plain-text format that stays readable on its own and renders as formatted HTML on any host. That is why each version sits under a `##` second-level heading — the single `#` is reserved for the `# Changelog` title at the top of the file — and the square brackets around `[1.0.0]` make it a reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
+A changelog is usually written in [Markdown][markdown]: a plain-text format that stays readable on its own and renders as formatted HTML on any host. Other lightweight formats such as [reStructuredText][rst] or [AsciiDoc][asciidoc] exist, and the conventions here carry over; the examples on this page use Markdown. That is why each version sits under a `##` second-level heading — the single `#` is reserved for the `# Changelog` title at the top of the file — and the square brackets around `[1.0.0]` make it a reference link. Resolve it once at the bottom of the file, pointing each version to a comparison with the one before it:
 
 ```
 [Unreleased]: https://github.com/your/project/compare/v1.1.0...HEAD
@@ -255,6 +255,8 @@ Its reach extends past software, too. Peer-reviewed research on software version
 [semver]: https://semver.org/
 [iso-8601]: https://www.iso.org/iso-8601-date-and-time-format.html
 [markdown]: https://commonmark.org/help/
+[rst]: https://docutils.sourceforge.io/rst.html
+[asciidoc]: https://asciidoc.org/
 [calver]: https://calver.org/
 [git]: https://en.wikipedia.org/wiki/Git
 [vcs]: https://en.wikipedia.org/wiki/Distributed_version_control


### PR DESCRIPTION
Several small additions to `source/en/2.0.0/index.html.md`, prompted by the discussion in #658, where commenters surfaced two recurring points of confusion: ISO dates not feeling "human-friendly," and how Markdown headings relate to the HTML links code hosts generate.

## 1. Date format guidance

The release-format paragraph read as a hard requirement and didn't address the "ISO dates aren't human-friendly" objection. The added text separates two distinct cases:

- **Written-out dates** (`July 17, 2017` / `17 July 2017`) are perfectly readable, but vary by region.
- **All-numeric dates** (`02-03-2017`) are genuinely ambiguous.

It frames `YYYY-MM-DD` as the form to *prefer* — because it reads the same everywhere — without implying another form breaks a changelog.

## 2. Why Markdown, and the heading hierarchy

The page is written in Markdown and uses headings and reference links throughout, but never said the changelog *is* a Markdown file or why. It now:

- Names the format where it first appears and explains it stays readable as plain text and renders to HTML on any host.
- Makes the heading hierarchy explicit: a version is a `##` second-level heading, nested under the single `#` reserved for the `# Changelog` title.
- Links a Markdown reference for readers who want the basics — [CommonMark's reference](https://commonmark.org/help/), chosen because it is ad-free.

## 3. Markdown headings as anchors

The crux of #658 was confusion about how Markdown headings become HTML anchors / element IDs on hosting platforms (the commenters talked past each other on this). The reference-link paragraph now notes that hosts render each `##` heading as an HTML anchor, so a clean heading doubles as a direct link to that version.

## 4. Alternative formats

"A changelog is written in Markdown" is softened to "usually," noting that other lightweight formats such as reStructuredText and AsciiDoc exist and that the conventions here carry over to them, while the examples on the page use Markdown.

## What is deliberately unchanged

The heading format itself (`## [x.y.z] - YYYY-MM-DD`) is left alone. As raised in #658, changing it would break merge drivers and parsers that rely on the current shape.

## Scope

English-only (`en/2.0.0`). The other locale copies of 2.0.0 still carry the previous text and would now be flagged as drifted by the translation tracker.

Refs #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4VZ8xA1rZG411SFsm7NZc