### PR TITLE
Add routing tests for the v2 preview default (#720)

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -2,6 +2,11 @@
 #   Config
 # --------------------------------------
 
+# Version routing (which spec version each entry point resolves to) lives in a
+# pure module so it can be unit-tested without booting Middleman. See
+# test/version_routing_test.rb.
+require_relative "tools/version_routing"
+
 # ----- Site ----- #
 # Last version should be the latest English version since Keep a Changelog is
 # first written in English, then translated into other languages later.
@@ -15,7 +20,7 @@ $versions = Dir.glob("source/en/*").map { |e| e.sub("source/en/", "") }.sort
 # notices to 2.0.0, without changing the default production build. For example:
 #   KAC_PREVIEW_V2=1 bundle exec middleman serve
 # To go live, drop the flag and set $last_version = "2.0.0" outright.
-$last_version = ENV["KAC_PREVIEW_V2"] ? "2.0.0" : "1.1.0"
+$last_version = VersionRouting.last_version(preview: ENV["KAC_PREVIEW_V2"])
 $previous_version = $versions[$versions.index($last_version) - 1]
 
 # Expose in-progress version drafts (e.g. a 2.0.0 still being written) only when
@@ -27,9 +32,8 @@ $previous_version = $versions[$versions.index($last_version) - 1]
 # routes to an unpublished draft. (Local-dev preview of newer drafts is handled at
 # render time by the build?-aware exposed_version_for helper below.)
 $published_version_for = lambda do |code|
-  $versions.select { |v|
-    File.directory?("source/#{code}/#{v}") && Gem::Version.new(v) <= Gem::Version.new($last_version)
-  }.max_by { |v| Gem::Version.new(v) }
+  installed = $versions.select { |v| File.directory?("source/#{code}/#{v}") }
+  VersionRouting.published_version_for(installed, last_version: $last_version)
 end
 
 # This list of languages populates the language navigation.
@@ -225,8 +229,7 @@ helpers do
   # in-progress 2.0.0) so they can be previewed and picked from the selector.
   def exposed_version_for(code)
     installed = $versions.select { |v| File.directory?("source/#{code}/#{v}") }
-    installed = installed.select { |v| Gem::Version.new(v) <= Gem::Version.new($last_version) } if build?
-    installed.max_by { |v| Gem::Version.new(v) }
+    VersionRouting.exposed_version_for(installed, last_version: $last_version, build: build?)
   end
 
   def available_translation_for(language)

--- a/test/version_routing_test.rb
+++ b/test/version_routing_test.rb
@@ -1,0 +1,125 @@
+require "minitest/autorun"
+require_relative "../tools/version_routing"
+
+# Routing tests for issue #720 ("Default-link to version 2"). They pin the
+# contract that 2.0.0 is built and previewable but never the default until it is
+# released, and they reproduce the one path that does surface 2.0.0 without a
+# ?preview param: a visitor who opted into the preview earlier (it persists).
+class VersionRoutingLastVersionTest < Minitest::Test
+  def test_default_is_the_published_version_not_the_draft
+    # No preview flag (the production build): "latest" stays 1.1.0, never 2.0.0.
+    assert_equal "1.1.0", VersionRouting.last_version(preview: nil)
+    assert_equal "1.1.0", VersionRouting.last_version(preview: false)
+  end
+
+  def test_preview_flag_promotes_the_draft
+    assert_equal "2.0.0", VersionRouting.last_version(preview: "1")
+    assert_equal "2.0.0", VersionRouting.last_version(preview: true)
+  end
+
+  def test_empty_string_flag_counts_as_on_like_an_env_var
+    # ENV["KAC_PREVIEW_V2"]="" is truthy in Ruby; config.rb relies on that.
+    assert_equal "2.0.0", VersionRouting.last_version(preview: "")
+  end
+end
+
+class VersionRoutingPublishedVersionTest < Minitest::Test
+  # A language that ships every English version, including the 2.0.0 draft.
+  FULLY_TRANSLATED = %w[0.3.0 1.0.0 1.1.0 2.0.0]
+
+  def test_production_caps_the_default_redirect_below_the_draft
+    # Even though 2.0.0 is installed, the default redirect target is 1.1.0.
+    assert_equal "1.1.0", VersionRouting.published_version_for(FULLY_TRANSLATED, last_version: "1.1.0")
+  end
+
+  def test_preview_lets_the_redirect_reach_the_draft
+    assert_equal "2.0.0", VersionRouting.published_version_for(FULLY_TRANSLATED, last_version: "2.0.0")
+  end
+
+  def test_partial_translation_falls_back_to_its_newest_installed_version
+    # German has no 2.0.0 yet, so it stays on its newest available spec.
+    assert_equal "1.1.0", VersionRouting.published_version_for(%w[1.0.0 1.1.0], last_version: "1.1.0")
+    assert_equal "1.0.0", VersionRouting.published_version_for(%w[0.3.0 1.0.0], last_version: "1.1.0")
+  end
+
+  def test_ordering_is_semantic_not_lexical
+    # 1.10.0 > 1.9.0 numerically even though it sorts earlier as a string.
+    assert_equal "1.10.0", VersionRouting.published_version_for(%w[1.9.0 1.10.0], last_version: "2.0.0")
+  end
+
+  def test_no_installed_version_yields_nil
+    assert_nil VersionRouting.published_version_for([], last_version: "1.1.0")
+  end
+end
+
+class VersionRoutingExposedVersionTest < Minitest::Test
+  INSTALLED = %w[0.3.0 1.0.0 1.1.0 2.0.0]
+
+  def test_build_caps_the_selector_at_the_published_version
+    # A production build must not expose the unreleased draft in the selector.
+    assert_equal "1.1.0", VersionRouting.exposed_version_for(INSTALLED, last_version: "1.1.0", build: true)
+  end
+
+  def test_serve_exposes_newer_drafts_for_local_preview
+    assert_equal "2.0.0", VersionRouting.exposed_version_for(INSTALLED, last_version: "1.1.0", build: false)
+  end
+
+  def test_preview_build_exposes_the_promoted_draft
+    assert_equal "2.0.0", VersionRouting.exposed_version_for(INSTALLED, last_version: "2.0.0", build: true)
+  end
+end
+
+# The "/" and "/en/" landing redirect (a Ruby mirror of the shipped JS). These
+# are the cases issue #720 is about: when does the bare site send a visitor to
+# 2.0.0 versus the published 1.1.0?
+class VersionRoutingLandingDecisionTest < Minitest::Test
+  def decide(param: nil, stored: nil, last_version: "1.1.0")
+    VersionRouting.landing_decision(param: param, stored: stored, last_version: last_version)
+  end
+
+  def test_no_param_no_storage_lands_on_the_published_version
+    target, stored = decide
+    assert_equal "1.1.0", target
+    assert_nil stored
+  end
+
+  def test_preview_param_routes_to_the_draft_and_is_remembered
+    target, stored = decide(param: "v2")
+    assert_equal "2.0.0", target
+    assert_equal "v2", stored # persisted for next time
+  end
+
+  # The crux of issue #720: once opted in, a later visit with NO param still
+  # lands on 2.0.0 because the choice is remembered. This is the "2.0.0 is the
+  # default even without ?preview" behavior — by design, but worth pinning.
+  def test_remembered_preview_makes_the_draft_the_default_without_a_param
+    target, stored = decide(param: nil, stored: "v2")
+    assert_equal "2.0.0", target
+    assert_equal "v2", stored
+  end
+
+  def test_preview_off_routes_to_published_and_clears_the_memory
+    target, stored = decide(param: "off", stored: "v2")
+    assert_equal "1.1.0", target
+    assert_nil stored
+  end
+
+  def test_preview_zero_is_an_alias_for_off
+    target, stored = decide(param: "0", stored: "v2")
+    assert_equal "1.1.0", target
+    assert_nil stored
+  end
+
+  def test_unrecognized_param_is_ignored_and_does_not_disturb_memory
+    target, stored = decide(param: "yes", stored: "v2")
+    assert_equal "2.0.0", target # falls back to the remembered choice
+    assert_equal "v2", stored
+  end
+
+  def test_default_follows_last_version_under_preview_build
+    # If 2.0.0 is actually released ($last_version flips), the non-preview path
+    # already points at it without anyone needing the param.
+    target, _ = decide(param: nil, stored: nil, last_version: "2.0.0")
+    assert_equal "2.0.0", target
+  end
+end

--- a/test/visual/routing.spec.js
+++ b/test/visual/routing.spec.js
@@ -1,0 +1,72 @@
+const { test, expect } = require("@playwright/test");
+
+// Routing tests for issue #720 ("Default-link to version 2"). They drive the
+// real built landing pages — the client-side redirect in source/index.html.erb
+// and source/en/index.html.erb plus the static per-language redirects — and pin
+// when a visitor lands on the unreleased 2.0.0 draft versus the published 1.1.0.
+//
+// These complement test/version_routing_test.rb: that unit-tests a Ruby mirror
+// of the decision; this exercises the shipped JavaScript and localStorage.
+
+const PUBLISHED = /\/en\/1\.1\.0\/$/;
+const PREVIEW = /\/en\/2\.0\.0\/$/;
+
+// Land on `path`, then wait for the JS-replace / meta-refresh redirect to settle
+// on a versioned spec page (e.g. /en/1.1.0/ or /de/1.1.0/) and return that URL.
+async function landed(page, path) {
+  // "commit" (not "load"): the landing page calls location.replace during load,
+  // which aborts a load-waiting goto. Then poll the URL until the redirect lands
+  // on a versioned spec page — polling (rather than waitForURL) avoids missing
+  // the synchronous replace event that fires before a listener could attach.
+  await page.goto(path, { waitUntil: "commit" });
+  await expect.poll(() => page.url(), { timeout: 15000 }).toMatch(/\/\d+\.\d+\.\d+\/$/);
+  return page.url();
+}
+
+test.describe("landing redirect (/)", () => {
+  test.use({ storageState: { cookies: [], origins: [] } }); // start with empty storage
+
+  test("with no preview param, defaults to the published version", async ({ page }) => {
+    expect(await landed(page, "/")).toMatch(PUBLISHED);
+  });
+
+  test("/en/ also defaults to the published version", async ({ page }) => {
+    expect(await landed(page, "/en/")).toMatch(PUBLISHED);
+  });
+
+  test("?preview=v2 opts into the 2.0.0 draft", async ({ page }) => {
+    expect(await landed(page, "/?preview=v2")).toMatch(PREVIEW);
+  });
+
+  // The heart of issue #720: opting into the preview persists, so a later bare
+  // visit with no param still lands on 2.0.0. That is "2.0.0 is the default even
+  // without ?preview" — by design (localStorage), but reproduced here explicitly.
+  test("a remembered preview makes 2.0.0 the default on the next bare visit", async ({ page }) => {
+    expect(await landed(page, "/?preview=v2")).toMatch(PREVIEW);
+    expect(await landed(page, "/")).toMatch(PREVIEW); // no param, yet still 2.0.0
+  });
+
+  test("?preview=off clears the memory and returns to the published version", async ({ page }) => {
+    expect(await landed(page, "/?preview=v2")).toMatch(PREVIEW);
+    expect(await landed(page, "/?preview=off")).toMatch(PUBLISHED);
+    expect(await landed(page, "/")).toMatch(PUBLISHED); // memory cleared
+  });
+});
+
+test.describe("without JavaScript", () => {
+  test.use({ javaScriptEnabled: false });
+
+  // The meta-refresh fallback must always send no-JS visitors to the published
+  // version, never the draft — even the PREVIEW constant is JS-only.
+  test("falls back to the published version via meta refresh", async ({ page }) => {
+    expect(await landed(page, "/?preview=v2")).toMatch(PUBLISHED);
+  });
+});
+
+test.describe("per-language static redirects", () => {
+  // A partially translated language has no 2.0.0 draft, so its bare path must
+  // redirect to its newest published spec — capped at the published version.
+  test("/de/ redirects to the newest published German spec", async ({ page }) => {
+    expect(await landed(page, "/de/")).toMatch(/\/de\/1\.1\.0\/$/);
+  });
+});

--- a/tools/version_routing.rb
+++ b/tools/version_routing.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rubygems" # Gem::Version
+
+# Pure, framework-free routing logic extracted from config.rb so it can be
+# unit-tested without booting Middleman. It answers one question for each entry
+# point: which spec version does a visitor land on?
+#
+#   - last_version          the published "latest" (preview promotes the v2 draft)
+#   - published_version_for the per-language default redirect target (never a draft)
+#   - exposed_version_for   the newest version offered in the version selector
+#   - landing_decision      the client-side "/" and "/en/" redirect — a Ruby mirror
+#                           of the JavaScript in source/index.html.erb and
+#                           source/en/index.html.erb, kept in sync so the preview
+#                           routing can be characterized in a fast test
+#
+# Keeping these here means the "2.0.0 must not become the default until it is
+# released" contract is asserted in CI, not just trusted to live config.
+module VersionRouting
+  module_function
+
+  # 2.0.0 is written and built on every run but stays unpublished — 1.1.0 remains
+  # latest — until release. The KAC_PREVIEW_V2 flag promotes the draft to latest.
+  PUBLISHED_VERSION = "1.1.0"
+  PREVIEW_VERSION = "2.0.0"
+
+  # The published "latest" version. A truthy preview flag promotes the draft.
+  # Mirrors config.rb's `ENV["KAC_PREVIEW_V2"] ? "2.0.0" : "1.1.0"`, so an empty
+  # string still counts as "on" (Ruby truthiness), matching the env-var behavior.
+  def last_version(preview:)
+    preview ? PREVIEW_VERSION : PUBLISHED_VERSION
+  end
+
+  # Newest installed version for a language that is at or below last_version, so
+  # production never routes to an unpublished draft. `installed` is the list of
+  # version strings that actually have a directory for the language.
+  def published_version_for(installed, last_version:)
+    cap = Gem::Version.new(last_version)
+    installed
+      .select { |v| Gem::Version.new(v) <= cap }
+      .max_by { |v| Gem::Version.new(v) }
+  end
+
+  # Newest installed version to expose in the version selector. A production build
+  # caps at last_version; serving locally exposes newer drafts so they can be
+  # previewed and linked before they are published.
+  def exposed_version_for(installed, last_version:, build:)
+    pool = installed
+    pool = pool.select { |v| Gem::Version.new(v) <= Gem::Version.new(last_version) } if build
+    pool.max_by { |v| Gem::Version.new(v) }
+  end
+
+  # The landing redirect for "/" and "/en/". Mirrors the shipped JavaScript: an
+  # explicit ?preview value wins and is remembered (`v2` opts in; `off`/`0` opt
+  # out); with no recognized param the remembered choice decides; the fallback is
+  # the published last_version.
+  #
+  # `param` is the raw ?preview query value (nil when absent). `stored` is the
+  # current localStorage value ("v2" or nil). Returns
+  # [target_version, stored_after] where stored_after is what localStorage should
+  # hold once the script runs (nil means cleared/absent) — so a test can show that
+  # 2.0.0 becomes the default on later visits even with no param, once opted in.
+  def landing_decision(param:, stored:, last_version:)
+    stored_after =
+      case param
+      when "v2" then "v2"
+      when "off", "0" then nil
+      else stored
+      end
+
+    preview =
+      if param == "v2"
+        true
+      elsif param == "off" || param == "0"
+        false
+      else
+        stored == "v2"
+      end
+
+    [preview ? PREVIEW_VERSION : last_version, stored_after]
+  end
+end


### PR DESCRIPTION
Adds routing tests that pin down when a visitor lands on the unreleased `2.0.0` draft versus the published `1.1.0`, prompted by #720.

The production build is already correct — `/`, `/en/`, and every per-language redirect resolve to `1.1.0`. The only place `2.0.0` becomes the default without a `?preview` param is client-side: once a visitor opts in with `?preview=v2`, the choice persists in `localStorage`. These tests lock that contract in; they don't change any behavior.

**Changes**
- Extract the version-routing logic out of `config.rb` into a pure `VersionRouting` module so it can be unit-tested without booting Middleman. `config.rb` now consumes it for `$last_version`, `$published_version_for`, and `exposed_version_for` — the production build output is byte-identical.
- `test/version_routing_test.rb` (minitest, runs in CI): published-vs-preview default, per-language capping below an unpublished draft, the build-vs-serve selector cap, and the landing decision — including the #720 case where a remembered `?preview=v2` makes `2.0.0` the default on a later bare visit.
- `test/visual/routing.spec.js` (Playwright): drives the real built pages through the shipped redirect JS and `localStorage` persistence — no-param default, `?preview=v2` opt-in and persistence, `?preview=off` clearing, the no-JS meta-refresh fallback, and per-language static redirects.

Refs #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)