### PR TITLE
Version + language selectors with translation-gap interstitials

### DIFF
--- a/.github/workflows/css-lint.yml
+++ b/.github/workflows/css-lint.yml
@@ -1,0 +1,32 @@
+name: CSS Lint
+
+# Lints the hand-authored CSS with stylelint (see .stylelintrc.cjs) and fails the
+# build on any violation, so mistakes like duplicate selectors, redundant
+# longhands, or invalid values can't merge.
+
+on:
+  push:
+    branches: [ "main", "2-0-0" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  stylelint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Lint CSS
+        run: npm run lint:css

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -1,0 +1,40 @@
+// Stylelint config for the hand-authored CSS (source/assets/stylesheets/*.css).
+//
+// We extend stylelint-config-standard for its *correctness* rules — duplicate
+// selectors, redundant longhands, invalid values, empty blocks, and the like —
+// which catch real mistakes. We switch off the purely stylistic opinions that
+// fight this file's deliberate, documented house style, so the linter stays
+// signal (bugs) and not noise (reformatting). The .sass files use a different
+// syntax and are linted by neither this config nor the lint script.
+module.exports = {
+  extends: ["stylelint-config-standard"],
+  rules: {
+    // Whitespace between rules/comments/declarations is authored intentionally.
+    "comment-empty-line-before": null,
+    "rule-empty-line-before": null,
+    "declaration-empty-line-before": null,
+    "custom-property-empty-line-before": null,
+    "at-rule-empty-line-before": null,
+
+    // Compact single-line rules (e.g. `.foo { a: 1; b: 2; }`) are house style.
+    "declaration-block-single-line-max-declarations": null,
+
+    // The palette is authored in decimal-lightness, unitless-hue oklch() on
+    // purpose, and media queries use classic min-/max- rather than range syntax.
+    "lightness-notation": null,
+    "hue-degree-notation": null,
+    "alpha-value-notation": null,
+    "color-function-notation": null,
+    "color-function-alias-notation": null,
+    "media-feature-range-notation": null,
+
+    // Intentional names and values.
+    "custom-property-pattern": null, // negative steps such as --step--1
+    "value-keyword-case": null, // proper-case font-family names (Roboto, Menlo…)
+    "property-no-vendor-prefix": null, // -webkit-mask etc. are needed for support
+
+    // Noisy against deliberately ordered, component-grouped rules; the real
+    // cascade is verified visually, not by source order.
+    "no-descending-specificity": null,
+  },
+};

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,14 @@ gem "redcarpet"
 gem "kramdown-parser-gfm"
 gem "standard", "~> 1.51"
 
-group :development, :test do 
+# activesupport, em-websocket, and tilt load these from the standard library but
+# don't declare them, and Ruby 3.4 drops them from the default gems. Declare them
+# so the bundle keeps working on 3.4+ (and Ruby stops warning on 3.3).
+gem "base64"
+gem "bigdecimal"
+gem "csv"
+gem "mutex_m"
+
+group :development, :test do
   gem "minitest"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,15 @@ GEM
     autoprefixer-rails (10.4.16.0)
       execjs (~> 2)
     backports (3.25.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.3)
     contracts (0.16.1)
+    csv (3.3.5)
     dotenv (3.1.2)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
@@ -103,6 +106,7 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     minitest (5.25.2)
+    mutex_m (0.3.0)
     padrino-helpers (0.15.3)
       i18n (>= 0.6.7, < 2)
       padrino-support (= 0.15.3)
@@ -181,6 +185,9 @@ PLATFORMS
 
 DEPENDENCIES
   addressable
+  base64
+  bigdecimal
+  csv
   kramdown-parser-gfm
   middleman (~> 4.5.1)
   middleman-autoprefixer
@@ -190,6 +197,7 @@ DEPENDENCIES
   middleman-minify-html
   middleman-syntax
   minitest
+  mutex_m
   redcarpet
   standard (~> 1.51)
 

--- a/config.rb
+++ b/config.rb
@@ -174,6 +174,37 @@ $languages.each do |language|
   redirect "#{code}/index.html", to: "#{code}/#{$published_version_for.call(code)}/index.html"
 end
 
+# Every (language, version) pair that hasn't been translated yet still resolves
+# to a real URL: a generated interstitial that explains the gap in the target
+# language (or English) and links to the English text plus how to contribute the
+# missing translation — instead of a 404. This is what lets the version/language
+# selectors offer *every* version for *every* language (issue #719): pick one we
+# don't have and you land somewhere helpful rather than nowhere.
+#
+# We mirror the selector's exposure rule: all spec versions when serving locally
+# (so an in-progress 2.0.0 draft previews), capped at the published $last_version
+# in a production build so unreleased drafts never ship.
+spec_versions = $versions.select { |v| File.directory?("source/en/#{v}") }
+
+generate_interstitials = lambda do |max_version|
+  $languages.each_key do |code|
+    spec_versions.each do |version|
+      next if max_version && Gem::Version.new(version) > Gem::Version.new(max_version)
+      next if File.directory?("source/#{code}/#{version}") # real translation exists
+      proxy "/#{code}/#{version}/index.html", "/missing.html",
+        locals: { language_code: code, version: version }, ignore: true
+    end
+  end
+end
+
+configure :development do
+  generate_interstitials.call(nil)
+end
+
+configure :build do
+  generate_interstitials.call($last_version)
+end
+
 # Patch releases of this project (e.g. 1.1.1) ship fixes to the site and tooling
 # without changing the changelog *specification*, so they never get their own
 # spec page — the spec stays at the x.y.0 minor (1.1.0). But those patch versions
@@ -232,6 +263,38 @@ helpers do
   def available_translation_for(language)
     version = exposed_version_for(language.first)
     "#{version} #{language.last[:name]}" if version
+  end
+
+  # The spec versions a visitor may pick from the version selector. We cap at the
+  # published $last_version in a production build so unreleased drafts (e.g. an
+  # in-progress 2.0.0) never surface; serving locally exposes the full set so
+  # drafts can be previewed. Oldest → newest.
+  def selectable_versions
+    versions = spec_versions
+    versions = versions.select { |v| Gem::Version.new(v) <= Gem::Version.new($last_version) } if build?
+    versions
+  end
+
+  # The real spec version directories ($versions also carries the en index
+  # template that the glob picks up), oldest → newest.
+  def spec_versions
+    dirs = $versions.select { |v| File.directory?("source/en/#{v}") }
+    dirs.sort_by { |v| Gem::Version.new(v) }
+  end
+
+  # Whether a given spec version has actually been translated for a language.
+  def version_available?(code, version)
+    File.directory?("source/#{code}/#{version}")
+  end
+
+  # major.minor for display (we never ship patch-level spec pages).
+  def display_version(version)
+    version.split(".").first(2).join(".")
+  end
+
+  # A language's autonym (e.g. "Français"), falling back to its code.
+  def language_name(code)
+    ($languages[code] || {})[:name] || code
   end
 
   # The release date for a version, read from CHANGELOG.md (e.g. the line

--- a/config.rb
+++ b/config.rb
@@ -155,6 +155,12 @@ $languages = {
 }
 $language_count = $languages.size
 
+# Localized copy for the "translation missing" interstitial (source/missing.html.haml),
+# keyed by the same language codes as $languages. English is the canonical set and
+# the per-key fallback — see data/interstitial.yml and the interstitial_string helper.
+require "yaml"
+$interstitial = YAML.load_file("data/interstitial.yml")
+
 activate :i18n,
   lang_map: $languages,
   mount_at_root: :en
@@ -260,11 +266,6 @@ helpers do
     installed.max_by { |v| Gem::Version.new(v) }
   end
 
-  def available_translation_for(language)
-    version = exposed_version_for(language.first)
-    "#{version} #{language.last[:name]}" if version
-  end
-
   # The spec versions a visitor may pick from the version selector. We cap at the
   # published $last_version in a production build so unreleased drafts (e.g. an
   # in-progress 2.0.0) never surface; serving locally exposes the full set so
@@ -295,6 +296,14 @@ helpers do
   # A language's autonym (e.g. "Français"), falling back to its code.
   def language_name(code)
     ($languages[code] || {})[:name] || code
+  end
+
+  # A localized interstitial string for a language, keyed by e.g. "title" or
+  # "lede". Falls back to English per key, so a partially-translated (or entirely
+  # untranslated) language still renders a complete page. Interpolate the result
+  # with String#% and the appropriate %{...} placeholders. See data/interstitial.yml.
+  def interstitial_string(code, key)
+    ($interstitial[code] || {})[key] || $interstitial["en"][key]
   end
 
   # The release date for a version, read from CHANGELOG.md (e.g. the line

--- a/data/interstitial.yml
+++ b/data/interstitial.yml
@@ -1,0 +1,159 @@
+# Localized copy for the "translation missing" interstitial (source/missing.html.haml).
+#
+# Keyed by the same language codes as $languages in config.rb. English ("en") is
+# the canonical set and the fallback: any language absent here — or any single
+# key it doesn't define — falls back to the English string, so the page is always
+# complete. To translate a language, copy the "en" block and translate the values;
+# leave the keys and the %{...} placeholders untouched.
+#
+# Placeholders:
+#   %{version}   spec version being viewed, e.g. "2.0"
+#   %{language}  the language's autonym, e.g. "Français"
+#   %{latest}    newest translated version for this language, e.g. "1.1"
+#   %{guide}     link to the contribution guide (uses guide_label as its text)
+#   %{coverage}  link to translation coverage (uses coverage_label as its text)
+#   %{pr}        link to open a pull request (uses pr_label as its text)
+#   %{issue}     link to file an issue (uses issue_label as its text)
+
+en:
+  title: "Keep a Changelog %{version} isn’t available in %{language} yet"
+  lede: "Here’s what you can do in the meantime."
+  read_english: "Read version %{version} in English"
+  read_latest: "Read the latest %{language} translation (%{latest})"
+  contribute_title: "Contribute the %{language} translation"
+  contribute_body: "Want to see %{version} in %{language}? The %{guide} walks you through adding a translation, and %{coverage} shows what’s already underway."
+  guide_label: "contribution guide"
+  coverage_label: "coverage"
+  cta: "Start by %{pr} or %{issue}."
+  pr_label: "opening a pull request"
+  issue_label: "filing an issue"
+
+de:
+  title: "Keep a Changelog %{version} ist noch nicht auf %{language} verfügbar"
+  lede: "Das kannst du in der Zwischenzeit tun."
+  read_english: "Version %{version} auf Englisch lesen"
+  read_latest: "Die neueste %{language}-Übersetzung lesen (%{latest})"
+  contribute_title: "Zur %{language}-Übersetzung beitragen"
+  contribute_body: "Möchtest du %{version} auf %{language} sehen? Der %{guide} zeigt dir, wie du eine Übersetzung hinzufügst, und die %{coverage} zeigt, was bereits in Arbeit ist."
+  guide_label: "Beitragsleitfaden"
+  coverage_label: "Übersetzungsübersicht"
+  cta: "Beginne, indem du %{pr} oder %{issue}."
+  pr_label: "einen Pull Request eröffnest"
+  issue_label: "ein Issue erstellst"
+
+es-ES:
+  title: "Keep a Changelog %{version} aún no está disponible en %{language}"
+  lede: "Esto es lo que puedes hacer mientras tanto."
+  read_english: "Leer la versión %{version} en inglés"
+  read_latest: "Leer la última traducción en %{language} (%{latest})"
+  contribute_title: "Contribuir a la traducción al %{language}"
+  contribute_body: "¿Quieres ver la %{version} en %{language}? La %{guide} te explica cómo añadir una traducción, y la %{coverage} muestra lo que ya está en marcha."
+  guide_label: "guía de contribución"
+  coverage_label: "cobertura de traducciones"
+  cta: "Empieza por %{pr} o %{issue}."
+  pr_label: "abrir un pull request"
+  issue_label: "crear una issue"
+
+fr:
+  title: "Keep a Changelog %{version} n’est pas encore disponible en %{language}"
+  lede: "Voici ce que vous pouvez faire en attendant."
+  read_english: "Lire la version %{version} en anglais"
+  read_latest: "Lire la dernière traduction en %{language} (%{latest})"
+  contribute_title: "Contribuer à la traduction en %{language}"
+  contribute_body: "Envie de voir la %{version} en %{language} ? Le %{guide} vous explique comment ajouter une traduction, et la %{coverage} montre ce qui est déjà en cours."
+  guide_label: "guide de contribution"
+  coverage_label: "couverture des traductions"
+  cta: "Commencez par %{pr} ou %{issue}."
+  pr_label: "ouvrir une pull request"
+  issue_label: "signaler une issue"
+
+it-IT:
+  title: "Keep a Changelog %{version} non è ancora disponibile in %{language}"
+  lede: "Ecco cosa puoi fare nel frattempo."
+  read_english: "Leggi la versione %{version} in inglese"
+  read_latest: "Leggi l’ultima traduzione in %{language} (%{latest})"
+  contribute_title: "Contribuisci alla traduzione in %{language}"
+  contribute_body: "Vuoi vedere la %{version} in %{language}? La %{guide} ti spiega come aggiungere una traduzione, e la %{coverage} mostra cosa è già in corso."
+  guide_label: "guida ai contributi"
+  coverage_label: "copertura delle traduzioni"
+  cta: "Inizia %{pr} o %{issue}."
+  pr_label: "aprendo una pull request"
+  issue_label: "segnalando una issue"
+
+nb:
+  title: "Keep a Changelog %{version} er ikke tilgjengelig på %{language} ennå"
+  lede: "Her er hva du kan gjøre i mellomtiden."
+  read_english: "Les versjon %{version} på engelsk"
+  read_latest: "Les den nyeste oversettelsen på %{language} (%{latest})"
+  contribute_title: "Bidra til oversettelsen på %{language}"
+  contribute_body: "Vil du se %{version} på %{language}? %{guide} viser deg hvordan du legger til en oversettelse, og %{coverage} viser hva som allerede er underveis."
+  guide_label: "bidragsguiden"
+  coverage_label: "oversettelsesdekningen"
+  cta: "Start med å %{pr} eller %{issue}."
+  pr_label: "åpne en pull request"
+  issue_label: "opprette en issue"
+
+pt-BR:
+  title: "Keep a Changelog %{version} ainda não está disponível em %{language}"
+  lede: "Veja o que você pode fazer enquanto isso."
+  read_english: "Ler a versão %{version} em inglês"
+  read_latest: "Ler a tradução mais recente em %{language} (%{latest})"
+  contribute_title: "Contribuir com a tradução em %{language}"
+  contribute_body: "Quer ver a %{version} em %{language}? O %{guide} mostra como adicionar uma tradução, e a %{coverage} mostra o que já está em andamento."
+  guide_label: "guia de contribuição"
+  coverage_label: "cobertura de traduções"
+  cta: "Comece %{pr} ou %{issue}."
+  pr_label: "abrindo um pull request"
+  issue_label: "criando uma issue"
+
+ru:
+  title: "Keep a Changelog %{version} пока недоступен на языке %{language}"
+  lede: "Вот что можно сделать пока что."
+  read_english: "Читать версию %{version} на английском"
+  read_latest: "Читать последний перевод на языке %{language} (%{latest})"
+  contribute_title: "Помочь с переводом на язык %{language}"
+  contribute_body: "Хотите увидеть %{version} на языке %{language}? %{guide} расскажет, как добавить перевод, а %{coverage} показывает, что уже в работе."
+  guide_label: "руководство для участников"
+  coverage_label: "страница покрытия переводов"
+  cta: "Начните с того, чтобы %{pr} или %{issue}."
+  pr_label: "открыть пул-реквест"
+  issue_label: "создать issue"
+
+sv:
+  title: "Keep a Changelog %{version} är inte tillgänglig på %{language} ännu"
+  lede: "Så här kan du göra under tiden."
+  read_english: "Läs version %{version} på engelska"
+  read_latest: "Läs den senaste översättningen på %{language} (%{latest})"
+  contribute_title: "Bidra till översättningen på %{language}"
+  contribute_body: "Vill du se %{version} på %{language}? %{guide} visar hur du lägger till en översättning, och %{coverage} visar vad som redan är på gång."
+  guide_label: "bidragsguiden"
+  coverage_label: "översättningstäckningen"
+  cta: "Börja med att %{pr} eller %{issue}."
+  pr_label: "öppna en pull request"
+  issue_label: "skapa en issue"
+
+zh-CN:
+  title: "Keep a Changelog %{version} 尚未提供%{language}版本"
+  lede: "在此期间，你可以这样做。"
+  read_english: "阅读 %{version} 英文版"
+  read_latest: "阅读最新的%{language}翻译（%{latest}）"
+  contribute_title: "参与%{language}翻译"
+  contribute_body: "想看到%{language}版的 %{version} 吗？%{guide}会指导你如何添加翻译，%{coverage}则显示当前的翻译进度。"
+  guide_label: "贡献指南"
+  coverage_label: "翻译覆盖情况"
+  cta: "从%{pr}或%{issue}开始。"
+  pr_label: "提交合并请求"
+  issue_label: "创建 issue"
+
+zh-TW:
+  title: "Keep a Changelog %{version} 尚未提供%{language}版本"
+  lede: "在此期間，你可以這樣做。"
+  read_english: "閱讀 %{version} 英文版"
+  read_latest: "閱讀最新的%{language}翻譯（%{latest}）"
+  contribute_title: "參與%{language}翻譯"
+  contribute_body: "想看到%{language}版的 %{version} 嗎？%{guide}會引導你如何新增翻譯，%{coverage}則顯示目前的翻譯進度。"
+  guide_label: "貢獻指南"
+  coverage_label: "翻譯涵蓋情況"
+  cta: "從%{pr}或%{issue}開始。"
+  pr_label: "提交合併請求"
+  issue_label: "建立 issue"

--- a/data/interstitial.yml
+++ b/data/interstitial.yml
@@ -12,8 +12,6 @@
 #   %{latest}    newest translated version for this language, e.g. "1.1"
 #   %{guide}     link to the contribution guide (uses guide_label as its text)
 #   %{coverage}  link to translation coverage (uses coverage_label as its text)
-#   %{pr}        link to open a pull request (uses pr_label as its text)
-#   %{issue}     link to file an issue (uses issue_label as its text)
 
 en:
   title: "Keep a Changelog %{version} isn’t available in %{language} yet"
@@ -21,12 +19,9 @@ en:
   read_english: "Read version %{version} in English"
   read_latest: "Read the latest %{language} translation (%{latest})"
   contribute_title: "Contribute the %{language} translation"
-  contribute_body: "Want to see %{version} in %{language}? The %{guide} walks you through adding a translation, and %{coverage} shows what’s already underway."
+  contribute_body: "Want to see version %{version} in %{language}? The %{guide} walks you through adding a translation, and %{coverage} shows what’s already underway."
   guide_label: "contribution guide"
   coverage_label: "coverage"
-  cta: "Start by %{pr} or %{issue}."
-  pr_label: "opening a pull request"
-  issue_label: "filing an issue"
 
 de:
   title: "Keep a Changelog %{version} ist noch nicht auf %{language} verfügbar"
@@ -34,12 +29,9 @@ de:
   read_english: "Version %{version} auf Englisch lesen"
   read_latest: "Die neueste %{language}-Übersetzung lesen (%{latest})"
   contribute_title: "Zur %{language}-Übersetzung beitragen"
-  contribute_body: "Möchtest du %{version} auf %{language} sehen? Der %{guide} zeigt dir, wie du eine Übersetzung hinzufügst, und die %{coverage} zeigt, was bereits in Arbeit ist."
+  contribute_body: "Möchtest du Version %{version} auf %{language} sehen? Der %{guide} zeigt dir, wie du eine Übersetzung hinzufügst, und die %{coverage} zeigt, was bereits in Arbeit ist."
   guide_label: "Beitragsleitfaden"
   coverage_label: "Übersetzungsübersicht"
-  cta: "Beginne, indem du %{pr} oder %{issue}."
-  pr_label: "einen Pull Request eröffnest"
-  issue_label: "ein Issue erstellst"
 
 es-ES:
   title: "Keep a Changelog %{version} aún no está disponible en %{language}"
@@ -47,12 +39,9 @@ es-ES:
   read_english: "Leer la versión %{version} en inglés"
   read_latest: "Leer la última traducción en %{language} (%{latest})"
   contribute_title: "Contribuir a la traducción al %{language}"
-  contribute_body: "¿Quieres ver la %{version} en %{language}? La %{guide} te explica cómo añadir una traducción, y la %{coverage} muestra lo que ya está en marcha."
+  contribute_body: "¿Quieres ver la versión %{version} en %{language}? La %{guide} te explica cómo añadir una traducción, y la %{coverage} muestra lo que ya está en marcha."
   guide_label: "guía de contribución"
   coverage_label: "cobertura de traducciones"
-  cta: "Empieza por %{pr} o %{issue}."
-  pr_label: "abrir un pull request"
-  issue_label: "crear una issue"
 
 fr:
   title: "Keep a Changelog %{version} n’est pas encore disponible en %{language}"
@@ -60,12 +49,9 @@ fr:
   read_english: "Lire la version %{version} en anglais"
   read_latest: "Lire la dernière traduction en %{language} (%{latest})"
   contribute_title: "Contribuer à la traduction en %{language}"
-  contribute_body: "Envie de voir la %{version} en %{language} ? Le %{guide} vous explique comment ajouter une traduction, et la %{coverage} montre ce qui est déjà en cours."
+  contribute_body: "Envie de voir la version %{version} en %{language} ? Le %{guide} vous explique comment ajouter une traduction, et la %{coverage} montre ce qui est déjà en cours."
   guide_label: "guide de contribution"
   coverage_label: "couverture des traductions"
-  cta: "Commencez par %{pr} ou %{issue}."
-  pr_label: "ouvrir une pull request"
-  issue_label: "signaler une issue"
 
 it-IT:
   title: "Keep a Changelog %{version} non è ancora disponibile in %{language}"
@@ -73,12 +59,9 @@ it-IT:
   read_english: "Leggi la versione %{version} in inglese"
   read_latest: "Leggi l’ultima traduzione in %{language} (%{latest})"
   contribute_title: "Contribuisci alla traduzione in %{language}"
-  contribute_body: "Vuoi vedere la %{version} in %{language}? La %{guide} ti spiega come aggiungere una traduzione, e la %{coverage} mostra cosa è già in corso."
+  contribute_body: "Vuoi vedere la versione %{version} in %{language}? La %{guide} ti spiega come aggiungere una traduzione, e la %{coverage} mostra cosa è già in corso."
   guide_label: "guida ai contributi"
   coverage_label: "copertura delle traduzioni"
-  cta: "Inizia %{pr} o %{issue}."
-  pr_label: "aprendo una pull request"
-  issue_label: "segnalando una issue"
 
 nb:
   title: "Keep a Changelog %{version} er ikke tilgjengelig på %{language} ennå"
@@ -86,12 +69,9 @@ nb:
   read_english: "Les versjon %{version} på engelsk"
   read_latest: "Les den nyeste oversettelsen på %{language} (%{latest})"
   contribute_title: "Bidra til oversettelsen på %{language}"
-  contribute_body: "Vil du se %{version} på %{language}? %{guide} viser deg hvordan du legger til en oversettelse, og %{coverage} viser hva som allerede er underveis."
+  contribute_body: "Vil du se versjon %{version} på %{language}? %{guide} viser deg hvordan du legger til en oversettelse, og %{coverage} viser hva som allerede er underveis."
   guide_label: "bidragsguiden"
   coverage_label: "oversettelsesdekningen"
-  cta: "Start med å %{pr} eller %{issue}."
-  pr_label: "åpne en pull request"
-  issue_label: "opprette en issue"
 
 pt-BR:
   title: "Keep a Changelog %{version} ainda não está disponível em %{language}"
@@ -99,12 +79,9 @@ pt-BR:
   read_english: "Ler a versão %{version} em inglês"
   read_latest: "Ler a tradução mais recente em %{language} (%{latest})"
   contribute_title: "Contribuir com a tradução em %{language}"
-  contribute_body: "Quer ver a %{version} em %{language}? O %{guide} mostra como adicionar uma tradução, e a %{coverage} mostra o que já está em andamento."
+  contribute_body: "Quer ver a versão %{version} em %{language}? O %{guide} mostra como adicionar uma tradução, e a %{coverage} mostra o que já está em andamento."
   guide_label: "guia de contribuição"
   coverage_label: "cobertura de traduções"
-  cta: "Comece %{pr} ou %{issue}."
-  pr_label: "abrindo um pull request"
-  issue_label: "criando uma issue"
 
 ru:
   title: "Keep a Changelog %{version} пока недоступен на языке %{language}"
@@ -112,12 +89,9 @@ ru:
   read_english: "Читать версию %{version} на английском"
   read_latest: "Читать последний перевод на языке %{language} (%{latest})"
   contribute_title: "Помочь с переводом на язык %{language}"
-  contribute_body: "Хотите увидеть %{version} на языке %{language}? %{guide} расскажет, как добавить перевод, а %{coverage} показывает, что уже в работе."
+  contribute_body: "Хотите увидеть версию %{version} на языке %{language}? %{guide} расскажет, как добавить перевод, а %{coverage} показывает, что уже в работе."
   guide_label: "руководство для участников"
   coverage_label: "страница покрытия переводов"
-  cta: "Начните с того, чтобы %{pr} или %{issue}."
-  pr_label: "открыть пул-реквест"
-  issue_label: "создать issue"
 
 sv:
   title: "Keep a Changelog %{version} är inte tillgänglig på %{language} ännu"
@@ -125,12 +99,9 @@ sv:
   read_english: "Läs version %{version} på engelska"
   read_latest: "Läs den senaste översättningen på %{language} (%{latest})"
   contribute_title: "Bidra till översättningen på %{language}"
-  contribute_body: "Vill du se %{version} på %{language}? %{guide} visar hur du lägger till en översättning, och %{coverage} visar vad som redan är på gång."
+  contribute_body: "Vill du se version %{version} på %{language}? %{guide} visar hur du lägger till en översättning, och %{coverage} visar vad som redan är på gång."
   guide_label: "bidragsguiden"
   coverage_label: "översättningstäckningen"
-  cta: "Börja med att %{pr} eller %{issue}."
-  pr_label: "öppna en pull request"
-  issue_label: "skapa en issue"
 
 zh-CN:
   title: "Keep a Changelog %{version} 尚未提供%{language}版本"
@@ -138,12 +109,9 @@ zh-CN:
   read_english: "阅读 %{version} 英文版"
   read_latest: "阅读最新的%{language}翻译（%{latest}）"
   contribute_title: "参与%{language}翻译"
-  contribute_body: "想看到%{language}版的 %{version} 吗？%{guide}会指导你如何添加翻译，%{coverage}则显示当前的翻译进度。"
+  contribute_body: "想看到 %{version} 版本的%{language}翻译吗？%{guide}会指导你如何添加翻译，%{coverage}则显示当前的翻译进度。"
   guide_label: "贡献指南"
   coverage_label: "翻译覆盖情况"
-  cta: "从%{pr}或%{issue}开始。"
-  pr_label: "提交合并请求"
-  issue_label: "创建 issue"
 
 zh-TW:
   title: "Keep a Changelog %{version} 尚未提供%{language}版本"
@@ -151,9 +119,116 @@ zh-TW:
   read_english: "閱讀 %{version} 英文版"
   read_latest: "閱讀最新的%{language}翻譯（%{latest}）"
   contribute_title: "參與%{language}翻譯"
-  contribute_body: "想看到%{language}版的 %{version} 嗎？%{guide}會引導你如何新增翻譯，%{coverage}則顯示目前的翻譯進度。"
+  contribute_body: "想看到 %{version} 版本的%{language}翻譯嗎？%{guide}會引導你如何新增翻譯，%{coverage}則顯示目前的翻譯進度。"
   guide_label: "貢獻指南"
   coverage_label: "翻譯涵蓋情況"
-  cta: "從%{pr}或%{issue}開始。"
-  pr_label: "提交合併請求"
-  issue_label: "建立 issue"
+
+ja:
+  title: "Keep a Changelog %{version} はまだ%{language}で利用できません"
+  lede: "それまでの間、次のことができます。"
+  read_english: "%{version} を英語で読む"
+  read_latest: "最新の%{language}翻訳を読む（%{latest}）"
+  contribute_title: "%{language}翻訳に貢献する"
+  contribute_body: "バージョン %{version} を%{language}で見たいですか？%{guide}では翻訳の追加方法を説明し、%{coverage}では現在進行中の翻訳を確認できます。"
+  guide_label: "貢献ガイド"
+  coverage_label: "翻訳状況"
+
+ko:
+  title: "Keep a Changelog %{version}은(는) 아직 %{language}로 제공되지 않습니다"
+  lede: "그동안 다음을 할 수 있습니다."
+  read_english: "%{version} 영어 버전 읽기"
+  read_latest: "최신 %{language} 번역 읽기 (%{latest})"
+  contribute_title: "%{language} 번역에 기여하기"
+  contribute_body: "%{version} 버전을 %{language}로 보고 싶으신가요? %{guide}에서 번역을 추가하는 방법을 안내하고, %{coverage}에서 현재 진행 상황을 확인할 수 있습니다."
+  guide_label: "기여 가이드"
+  coverage_label: "번역 현황"
+
+nl:
+  title: "Keep a Changelog %{version} is nog niet beschikbaar in het %{language}"
+  lede: "Dit kun je in de tussentijd doen."
+  read_english: "Lees versie %{version} in het Engels"
+  read_latest: "Lees de nieuwste vertaling in het %{language} (%{latest})"
+  contribute_title: "Draag bij aan de vertaling in het %{language}"
+  contribute_body: "Wil je versie %{version} in het %{language} zien? De %{guide} legt uit hoe je een vertaling toevoegt, en %{coverage} laat zien wat er al onderweg is."
+  guide_label: "bijdragegids"
+  coverage_label: "vertaaldekking"
+
+pl:
+  title: "Keep a Changelog %{version} nie został jeszcze przetłumaczony na %{language}"
+  lede: "Oto co możesz zrobić w międzyczasie."
+  read_english: "Przeczytaj wersję %{version} po angielsku"
+  read_latest: "Przeczytaj najnowsze tłumaczenie na %{language} (%{latest})"
+  contribute_title: "Pomóż w tłumaczeniu na %{language}"
+  contribute_body: "Chcesz zobaczyć wersję %{version} przetłumaczoną na %{language}? %{guide} wyjaśnia, jak dodać tłumaczenie, a %{coverage} pokazuje, co jest już w toku."
+  guide_label: "przewodnik dla współtwórców"
+  coverage_label: "stan tłumaczeń"
+
+cs:
+  title: "Keep a Changelog %{version} zatím není k dispozici v jazyce %{language}"
+  lede: "Mezitím můžete udělat toto:"
+  read_english: "Přečtěte si verzi %{version} v angličtině"
+  read_latest: "Přečtěte si nejnovější překlad do jazyka %{language} (%{latest})"
+  contribute_title: "Přispějte k překladu do jazyka %{language}"
+  contribute_body: "Chcete vidět verzi %{version} v jazyce %{language}? %{guide} vás provede přidáním překladu a %{coverage} ukazuje, co se už připravuje."
+  guide_label: "průvodce pro přispěvatele"
+  coverage_label: "pokrytí překladů"
+
+da:
+  title: "Keep a Changelog %{version} er endnu ikke tilgængelig på %{language}"
+  lede: "Her er, hvad du kan gøre i mellemtiden."
+  read_english: "Læs version %{version} på engelsk"
+  read_latest: "Læs den nyeste %{language}-oversættelse (%{latest})"
+  contribute_title: "Bidrag til %{language}-oversættelsen"
+  contribute_body: "Vil du se version %{version} på %{language}? %{guide} viser dig, hvordan du tilføjer en oversættelse, og %{coverage} viser, hvad der allerede er i gang."
+  guide_label: "bidragsguide"
+  coverage_label: "oversættelsesdækning"
+
+tr-TR:
+  title: "Keep a Changelog %{version} henüz %{language} olarak mevcut değil"
+  lede: "Bu arada şunları yapabilirsiniz:"
+  read_english: "%{version} sürümünü İngilizce okuyun"
+  read_latest: "En son %{language} çevirisini okuyun (%{latest})"
+  contribute_title: "%{language} çevirisine katkıda bulunun"
+  contribute_body: "%{version} sürümünü %{language} olarak görmek ister misiniz? %{guide} bir çevirinin nasıl ekleneceğini anlatır, %{coverage} ise halihazırda devam eden çalışmaları gösterir."
+  guide_label: "katkı kılavuzu"
+  coverage_label: "çeviri kapsamı"
+
+uk:
+  title: "Keep a Changelog %{version} поки що недоступний мовою %{language}"
+  lede: "Ось що можна зробити тим часом."
+  read_english: "Читати версію %{version} англійською"
+  read_latest: "Читати останній переклад мовою %{language} (%{latest})"
+  contribute_title: "Допомогти з перекладом мовою %{language}"
+  contribute_body: "Хочете побачити версію %{version} мовою %{language}? %{guide} розповість, як додати переклад, а %{coverage} показує, що вже в роботі."
+  guide_label: "посібник для учасників"
+  coverage_label: "сторінка покриття перекладів"
+
+ro:
+  title: "Keep a Changelog %{version} nu este încă disponibil în %{language}"
+  lede: "Iată ce poți face între timp."
+  read_english: "Citește versiunea %{version} în engleză"
+  read_latest: "Citește cea mai recentă traducere în %{language} (%{latest})"
+  contribute_title: "Contribuie la traducerea în %{language}"
+  contribute_body: "Vrei să vezi versiunea %{version} în %{language}? %{guide} îți explică cum să adaugi o traducere, iar %{coverage} arată ce este deja în lucru."
+  guide_label: "ghidul de contribuție"
+  coverage_label: "acoperirea traducerilor"
+
+id-ID:
+  title: "Keep a Changelog %{version} belum tersedia dalam bahasa %{language}"
+  lede: "Inilah yang bisa Anda lakukan sementara itu."
+  read_english: "Baca versi %{version} dalam bahasa Inggris"
+  read_latest: "Baca terjemahan bahasa %{language} terbaru (%{latest})"
+  contribute_title: "Bantu terjemahan bahasa %{language}"
+  contribute_body: "Ingin melihat versi %{version} dalam bahasa %{language}? %{guide} menjelaskan cara menambahkan terjemahan, dan %{coverage} menunjukkan apa yang sedang dikerjakan."
+  guide_label: "panduan kontribusi"
+  coverage_label: "cakupan terjemahan"
+
+ar:
+  title: "Keep a Changelog %{version} غير متوفر بعد باللغة %{language}"
+  lede: "إليك ما يمكنك فعله في هذه الأثناء."
+  read_english: "اقرأ الإصدار %{version} بالإنجليزية"
+  read_latest: "اقرأ أحدث ترجمة إلى %{language} (%{latest})"
+  contribute_title: "ساهم في الترجمة إلى %{language}"
+  contribute_body: "هل تريد رؤية الإصدار %{version} باللغة %{language}؟ يشرح لك %{guide} كيفية إضافة ترجمة، ويعرض %{coverage} ما هو قيد التنفيذ بالفعل."
+  guide_label: "دليل المساهمة"
+  coverage_label: "تغطية الترجمة"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.60.0",
-        "axe-core": "^4.12.0"
+        "axe-core": "^4.12.0",
+        "stylelint": "^17.14.0",
+        "stylelint-config-standard": "^40.0.0"
       }
     },
     "node_modules/@axe-core/playwright": {
@@ -32,6 +34,263 @@
         "node": ">=4"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cacheable/memory": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.2.0.tgz",
+      "integrity": "sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==",
+      "dev": true,
+      "dependencies": {
+        "@cacheable/utils": "^2.5.0",
+        "@keyv/bigmap": "^1.3.1",
+        "hookified": "^1.15.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@cacheable/utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.5.0.tgz",
+      "integrity": "sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==",
+      "dev": true,
+      "dependencies": {
+        "hashery": "^1.5.1",
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-5.0.0.tgz",
+      "integrity": "sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/selector-resolve-nested": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-4.0.0.tgz",
+      "integrity": "sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@keyv/bigmap": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+      "integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
+      "dev": true,
+      "dependencies": {
+        "hashery": "^1.4.0",
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.6.0"
+      }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.60.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
@@ -47,6 +306,76 @@
         "node": ">=18"
       }
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
@@ -55,6 +384,259 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.5.0.tgz",
+      "integrity": "sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==",
+      "dev": true,
+      "dependencies": {
+        "@cacheable/memory": "^2.2.0",
+        "@cacheable/utils": "^2.5.0",
+        "hookified": "^1.15.0",
+        "keyv": "^5.6.0",
+        "qified": "^0.10.1"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
+      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.5.tgz",
+      "integrity": "sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^6.1.23"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "6.1.23",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.23.tgz",
+      "integrity": "sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==",
+      "dev": true,
+      "dependencies": {
+        "cacheable": "^2.5.0",
+        "flatted": "^3.4.2",
+        "hookified": "^1.15.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -68,6 +650,429 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
+    "node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hashery": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+      "integrity": "sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==",
+      "dev": true,
+      "dependencies": {
+        "hookified": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/hookified": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+      "integrity": "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==",
+      "dev": true
+    },
+    "node_modules/html-tags": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-5.1.0.tgz",
+      "integrity": "sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
+    "node_modules/mathml-tag-names": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-4.0.0.tgz",
+      "integrity": "sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
+    },
+    "node_modules/meow": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.1.0.tgz",
+      "integrity": "sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/playwright": {
@@ -98,6 +1103,494 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
+    "node_modules/qified": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.10.1.tgz",
+      "integrity": "sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==",
+      "dev": true,
+      "dependencies": {
+        "hookified": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/qified/node_modules/hookified": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
+      "dev": true
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "17.14.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.14.0.tgz",
+      "integrity": "sha512-8xkHPpdqYryeIsOgfsYTmr6cIeC4nLYWk5S8BPxpodq8mIuepggkMljsHewWfuAjj/+qpRKou2QerhjMH3iasg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-calc": "^3.2.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.5",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/media-query-list-parser": "^5.0.0",
+        "@csstools/selector-resolve-nested": "^4.0.0",
+        "@csstools/selector-specificity": "^6.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.2",
+        "css-functions-list": "^3.3.3",
+        "css-tree": "^3.2.1",
+        "debug": "^4.4.3",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^11.1.3",
+        "global-modules": "^2.0.0",
+        "globby": "^16.2.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^5.1.0",
+        "ignore": "^7.0.5",
+        "import-meta-resolve": "^4.2.0",
+        "mathml-tag-names": "^4.0.0",
+        "meow": "^14.1.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.15",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.4",
+        "postcss-value-parser": "^4.2.0",
+        "string-width": "^8.2.1",
+        "supports-hyperlinks": "^4.4.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^7.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-18.0.0.tgz",
+      "integrity": "sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "40.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-40.0.0.tgz",
+      "integrity": "sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "dependencies": {
+        "stylelint-config-recommended": "^18.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^17.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-7.0.1.tgz",
+      "integrity": "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==",
+      "dev": true,
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
-    "axe-core": "^4.12.0"
+    "axe-core": "^4.12.0",
+    "stylelint": "^17.14.0",
+    "stylelint-config-standard": "^40.0.0"
   },
   "scripts": {
     "snapshot:baseline": "playwright test --update-snapshots",
-    "snapshot:check": "playwright test"
+    "snapshot:check": "playwright test",
+    "lint:css": "stylelint \"source/assets/stylesheets/**/*.css\"",
+    "lint:css:fix": "stylelint \"source/assets/stylesheets/**/*.css\" --fix"
   }
 }

--- a/source/assets/javascripts/all.js
+++ b/source/assets/javascripts/all.js
@@ -9,14 +9,18 @@ document.addEventListener("DOMContentLoaded", function(){
     else if (previewParam === 'off' || previewParam === '0') { localStorage.removeItem('kac-preview'); }
   } catch (e) {}
 
-  var select = document.querySelector('.locales select');
-  if (select) {
+  // Version and/or language selectors. Each option's value is a "lang/version/"
+  // path, so changing either one just navigates there — a real spec page when we
+  // have that translation, or a generated interstitial when we don't.
+  var selects = document.querySelectorAll('.locales select');
+  Array.prototype.forEach.call(selects, function(select){
     select.addEventListener('change', function(event){
-      origin = window.location.origin;
-      languageCode = event.currentTarget.selectedOptions[0].value
-      window.location.replace(origin + "/" + languageCode)
+      var origin = window.location.origin;
+      var target = event.currentTarget.selectedOptions[0].value;
+      window.location.replace(origin + "/" + target);
     });
-  }
+  });
+  var select = selects[0];
 
   // On very narrow viewports the language picker collapses behind a globe
   // button (see the max-width query in v2.css). Toggle it open; the select is

--- a/source/assets/stylesheets/application.css.sass
+++ b/source/assets/stylesheets/application.css.sass
@@ -115,12 +115,30 @@ header
   border-radius: .5rem
   padding: .7rem 1rem
 
-.locales li
-  float: right
-  font-size: 0.7em
-  display: inline
-  list-style-type: none
+// Dual version + language selectors (shared v2 partial). The narrow-screen
+// toggle is a v2-only affordance, so hide it and always show both fields.
+.locales-toggle
+  display: none
+
+.locale-fields
+  display: flex
+  flex-direction: column
+  gap: .4rem
+
+.locale-field
+  display: flex
+  align-items: center
+  justify-content: space-between
+  gap: .5rem
+
+.locales-text
+  font-size: .85em
   white-space: nowrap
+
+.locale-select
+  font-family: inherit
+  font-size: .9em
+  max-width: 11rem
 
 pre, code
   background-color: $color-light-sand

--- a/source/assets/stylesheets/legacy.css.sass
+++ b/source/assets/stylesheets/legacy.css.sass
@@ -113,11 +113,32 @@ footer
   overflow-x: auto
   height: 20em
 
-.locales li
-  display: inline
-  list-style-type: none
-  padding-right: 20px
+// Dual version + language selectors (shared v2 partial). 0.3.0 predated the
+// picker, so give it just enough to be usable and accessible: centered, both
+// fields always shown, and the v2-only narrow-screen toggle hidden.
+.locales
+  text-align: center
+  margin: 1em auto
+
+.locales-toggle
+  display: none
+
+.locale-fields
+  display: inline-flex
+  flex-wrap: wrap
+  justify-content: center
+  gap: .3rem 1rem
+
+.locale-field
+  display: inline-flex
+  align-items: center
+  gap: .4rem
+
+.locales-text
   white-space: nowrap
+
+.locale-select
+  font-family: inherit
 
 pre, code
   font-family: $source-code-font-family

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -265,7 +265,8 @@
     margin-inline-end: 0.25rem;
     background: var(--rule);
   }
-  #language-select {
+  /* Both the version and language selects share one look. */
+  .locales select {
     font: inherit;
     color: var(--text);
     background: var(--bg);
@@ -274,6 +275,13 @@
     padding: 0.4em 0.6em;
     max-inline-size: 16rem;
   }
+  /* The two selectors sit side by side; the version one is narrow (just a
+     number), the language one carries the names. */
+  .locale-fields { display: inline-flex; align-items: center; gap: var(--space-xs); }
+  .locale-field { display: inline-flex; align-items: center; }
+  /* No per-field globe — the collapse globe lives on .locales-toggle. */
+  .locale-field::before { content: none; }
+  #version-select { max-inline-size: 6.5rem; }
   /* Show a compact globe icon in place of the "Languages (N):" text at every
      width; the text stays in the DOM (and the label's title) for screen readers. */
   .locales-text {
@@ -363,8 +371,9 @@
     text-wrap: pretty;
   }
 
-  /* Very narrow: collapse the language picker behind the globe so the header
-     stays on one row. Tapping the globe reveals the select (JS sets data-open). */
+  /* Very narrow: collapse the version + language selectors behind the globe so
+     the header stays on one row. Tapping the globe reveals them (JS sets
+     data-open). */
   @media (max-width: 30rem) {
     /* Show the brand mark in the header (before the picker) at this width, and
        hide it in the hero (rule in the content layer) so it doesn't crowd the
@@ -372,25 +381,34 @@
     article > header .mark { display: inline-block; }
     .locales::before { display: block; }
     .locales-toggle { display: inline-grid; }
-    .locales label { display: none; }
-    #language-select { display: none; }
-    /* Open as a popover anchored under the globe so it doesn't reflow the nav.
-       The width cap lives in a custom property so the Sass minifier passes the
-       min()/calc through untouched. */
-    .locales[data-open] #language-select {
+    .locale-fields { display: none; }
+    /* Open as a stacked popover anchored under the globe so it doesn't reflow the
+       nav. The width cap lives in a custom property so the Sass minifier passes
+       the min()/calc through untouched. */
+    .locales[data-open] .locale-fields {
       --locale-popover-max: min(16rem, calc(100vw - 2 * var(--space-m)));
-      display: inline-block;
+      display: flex;
+      flex-direction: column;
+      align-items: stretch;
+      gap: var(--space-2xs);
       position: absolute;
       inset-block-start: 100%;
       inset-inline-start: 0;
       margin-block-start: var(--space-2xs);
       z-index: 20;
+      padding: var(--space-xs);
+      background: var(--surface);
+      border: 1px solid var(--rule);
+      border-radius: var(--radius);
       max-inline-size: var(--locale-popover-max);
       box-shadow: 0 6px 20px -8px rgba(0, 0, 0, 0.45);
     }
-    /* Grow the white header while the picker is open so the revealed select
-       rests on the header surface instead of hanging over the orange hero. */
-    article > header:has(.locales[data-open]) { padding-block-end: 3.25rem; }
+    .locales[data-open] .locale-field { display: flex; }
+    .locales[data-open] .locale-fields select { inline-size: 100%; max-inline-size: none; }
+    .locales[data-open] .locale-fields #version-select { max-inline-size: none; }
+    /* Grow the white header while the picker is open so the revealed selects
+       rest on the header surface instead of hanging over the orange hero. */
+    article > header:has(.locales[data-open]) { padding-block-end: 5.5rem; }
   }
 }
 
@@ -895,4 +913,64 @@
     from { transform: translateY(-100%); }
     to { transform: translateY(0); }
   }
+
+  /* ---------------------------------------------- missing-translation page */
+  /* The interstitial has no hero, so surface the brand mark and wordmark in its
+     header at every width (the regular pages hide them outside the pinned state). */
+  .missing-page article > header .mark { display: inline-block; }
+  .missing-page .header-title { display: inline-block; }
+
+  .missing {
+    max-inline-size: 44rem;
+    margin: var(--space-2xl) auto;
+    padding: 0 var(--space-m);
+  }
+  .missing-eyebrow {
+    margin: 0 0 var(--space-2xs);
+    font-size: var(--step--1);
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
+  .missing-title { margin: 0 0 var(--space-s); }
+  .missing-lede {
+    margin: 0 0 var(--space-l);
+    font-size: var(--step-1);
+    color: var(--muted);
+    text-wrap: pretty;
+  }
+  .missing-actions {
+    margin: 0 0 var(--space-xl);
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-s);
+  }
+  .missing-actions a {
+    display: inline-block;
+    padding: 0.55em 1em;
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--link);
+    text-decoration: none;
+  }
+  .missing-actions a:hover { border-color: var(--link); }
+  .missing-contribute {
+    padding: var(--space-l);
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .missing-contribute h2 { margin-block-start: 0; }
+  .missing-contribute code {
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--text) 8%, transparent);
+    font-family: "Source Code Pro", monospace;
+    font-size: 0.9em;
+  }
+  .missing-meta { margin-block-end: 0; font-size: var(--step--1); color: var(--muted); }
 }

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -279,8 +279,6 @@
      number), the language one carries the names. */
   .locale-fields { display: inline-flex; align-items: center; gap: var(--space-xs); }
   .locale-field { display: inline-flex; align-items: center; }
-  /* No per-field globe — the collapse globe lives on .locales-toggle. */
-  .locale-field::before { content: none; }
   #version-select { max-inline-size: 6.5rem; }
   /* Show a compact globe icon in place of the "Languages (N):" text at every
      width; the text stays in the DOM (and the label's title) for screen readers. */
@@ -295,9 +293,10 @@
     white-space: nowrap;
   }
   /* Flex-center the globe so it sits on the header axis without depending on
-     baseline/vertical-align nudges. */
+     baseline/vertical-align nudges. The globe belongs to the legacy single
+     picker's label only — the v2 .locale-field labels opt out. */
   .locales label { display: inline-flex; align-items: center; }
-  .locales label::before {
+  .locales label:not(.locale-field)::before {
     content: "";
     display: block;
     inline-size: 1.3em;

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -279,7 +279,11 @@
      number), the language one carries the names. */
   .locale-fields { display: inline-flex; align-items: center; gap: var(--space-xs); }
   .locale-field { display: inline-flex; align-items: center; }
-  #version-select { max-inline-size: 6.5rem; }
+  #version-select { max-inline-size: 8.5rem; }
+  /* Dim the untranslated options where the browser honours option colors
+     (Firefox, Chromium); they stay selectable so the pick reaches the
+     interstitial, and the "(n/a)" tag covers browsers that ignore this. */
+  .locale-select option[data-available="false"] { color: var(--muted); }
   /* Show a compact globe icon in place of the "Languages (N):" text at every
      width; the text stays in the DOM (and the label's title) for screen readers. */
   .locales-text {

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -936,9 +936,9 @@
     font-size: var(--step-2);
   }
 
-  /* Everything below the heading is capped back to a comfortable reading measure. */
+  /* The lede and contribute box keep a comfortable reading measure; the action
+     row spans the wider block so its buttons sit side by side rather than stack. */
   .missing-lede,
-  .missing-actions,
   .missing-contribute { max-inline-size: 44rem; }
 
   /* The action buttons and the contribute box share one surface-panel look, so
@@ -951,7 +951,7 @@
   }
 
   .missing-lede {
-    margin: 0 0 var(--space-m);
+    margin: 0 0 var(--space-s);
     font-size: var(--step-1);
     color: var(--muted);
     text-wrap: pretty;
@@ -961,7 +961,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-s);
-    margin: 0 0 var(--space-l);
+    margin: 0 0 var(--space-m);
     padding: 0;
     list-style: none;
   }
@@ -973,17 +973,11 @@
   }
   .missing-actions a:hover { border-color: var(--link); }
 
-  .missing-contribute { padding: var(--space-xl) var(--space-l); }
-  /* Even vertical rhythm between the heading, body, and call to action. */
+  .missing-contribute { padding: var(--space-m) var(--space-l); }
+  /* Even vertical rhythm between the heading and body. */
   .missing-contribute > * { margin-block: 0; }
-  .missing-contribute > * + * { margin-block-start: var(--space-m); }
-  .missing-contribute h2 {
-    font-size: var(--step-1);
-    text-wrap: nowrap;
-  }
-  .missing-meta {
-    font-size: var(--step--1);
-    color: var(--muted);
-    text-align: end;
-  }
+  .missing-contribute > * + * { margin-block-start: var(--space-s); }
+  /* Smaller than the page heading; wraps (via the global balance) only when the
+     box is too narrow, e.g. on phones — otherwise it overflows and scrolls. */
+  .missing-contribute h2 { font-size: var(--step-1); }
 }

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -819,11 +819,13 @@
     .article-body > .toc,
     .article-body > .content { grid-column: 1; }
     .article-body > .toc { justify-self: center; }
-    .article-body > .content { justify-self: stretch; }
-    /* Tighten the stack: the toggle sits close under the version, and the
-       content starts soon after, instead of floating in large gaps. */
+    /* Tighten the stack: the content stretches full width and starts soon after
+       the toggle, which itself sits close under the version. */
     .toc-disclosure > summary { margin-block-start: var(--space-2xs); }
-    .article-body > .content { padding-block-start: var(--space-s); }
+    .article-body > .content {
+      justify-self: stretch;
+      padding-block-start: var(--space-s);
+    }
     .toc-disclosure[open] > nav {
       position: static;
       margin-inline: auto;
@@ -845,8 +847,7 @@
     .article-body > .toc {
       grid-column: 1;
       grid-row: 1 / span 2;
-      justify-self: start;
-      align-self: start;
+      place-self: start;
       text-align: start;
       inline-size: 15rem;
       max-inline-size: none;
@@ -919,61 +920,70 @@
 
   /* ---------------------------------------------- missing-translation page */
   /* The interstitial has no hero, so surface the brand mark and wordmark in its
-     header at every width (the regular pages hide them outside the pinned state). */
-  .missing-page article > header .mark { display: inline-block; }
+     header at every width (regular pages hide them outside the pinned state). */
+  .missing-page article > header .mark,
   .missing-page .header-title { display: inline-block; }
 
+  /* The block runs wider than the body's reading measure so a long heading can
+     use the available width instead of wrapping inside a narrow column. */
   .missing {
-    max-inline-size: 44rem;
-    margin: var(--space-2xl) auto;
+    max-inline-size: 72rem;
+    margin: var(--space-xl) auto;
     padding: 0 var(--space-m);
   }
-  .missing-eyebrow {
-    margin: 0 0 var(--space-2xs);
-    font-size: var(--step--1);
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--accent);
+  .missing-title {
+    margin: 0 0 var(--space-s);
+    font-size: var(--step-2);
   }
-  .missing-title { margin: 0 0 var(--space-s); }
+
+  /* Everything below the heading is capped back to a comfortable reading measure. */
+  .missing-lede,
+  .missing-actions,
+  .missing-contribute { max-inline-size: 44rem; }
+
+  /* The action buttons and the contribute box share one surface-panel look, so
+     keep its border, radius, and background defined in a single place. */
+  .missing-actions a,
+  .missing-contribute {
+    border: 1px solid var(--rule);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+
   .missing-lede {
-    margin: 0 0 var(--space-l);
+    margin: 0 0 var(--space-m);
     font-size: var(--step-1);
     color: var(--muted);
     text-wrap: pretty;
   }
+
   .missing-actions {
-    margin: 0 0 var(--space-xl);
-    padding: 0;
-    list-style: none;
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-s);
+    margin: 0 0 var(--space-l);
+    padding: 0;
+    list-style: none;
   }
   .missing-actions a {
     display: inline-block;
     padding: 0.55em 1em;
-    border: 1px solid var(--rule);
-    border-radius: var(--radius);
-    background: var(--surface);
     color: var(--link);
     text-decoration: none;
   }
   .missing-actions a:hover { border-color: var(--link); }
-  .missing-contribute {
-    padding: var(--space-l);
-    border: 1px solid var(--rule);
-    border-radius: var(--radius);
-    background: var(--surface);
+
+  .missing-contribute { padding: var(--space-xl) var(--space-l); }
+  /* Even vertical rhythm between the heading, body, and call to action. */
+  .missing-contribute > * { margin-block: 0; }
+  .missing-contribute > * + * { margin-block-start: var(--space-m); }
+  .missing-contribute h2 {
+    font-size: var(--step-1);
+    text-wrap: nowrap;
   }
-  .missing-contribute h2 { margin-block-start: 0; }
-  .missing-contribute code {
-    padding: 0.1em 0.35em;
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--text) 8%, transparent);
-    font-family: "Source Code Pro", monospace;
-    font-size: 0.9em;
+  .missing-meta {
+    font-size: var(--step--1);
+    color: var(--muted);
+    text-align: end;
   }
-  .missing-meta { margin-block-end: 0; font-size: var(--step--1); color: var(--muted); }
 }

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -94,19 +94,25 @@
           %span.mark{ role: "img", "aria-label": "Keep a Changelog" }
           %span.header-title{ "aria-hidden": "true" } Keep a Changelog
         %nav.locales{ role: "navigation" }
-          %button.locales-toggle{ type: "button", "aria-expanded": "false", "aria-controls": "language-select", "aria-label": "Show language menu", title: "Pick one of the #{$language_count} translations" }
-          %label{ for: "language-select", title: "Pick one of the #{$language_count} translations" }
-            %span.locales-text= "Languages (#{$languages.count}):"
-          %select{ name: "language", id: "language-select", "aria-label": "Choose a language" }
-            - $languages.each do |language|
-              - version = exposed_version_for(language.first)
-              - if version
-                - selected = language_code == language.first
-                -# Show only major.minor (we don't ship patch releases); the URL keeps the full version.
-                - display_version = version.split(".").first(2).join(".")
-                - label = "#{display_version} #{language.last[:name]}"
-                %option{ selected: selected, label: label, value: "#{language.first}/#{version}/" }
-                  = label
+          -# v2 ships separate version + language selectors that expose every
+          -# version for every language (issue #719). Legacy pages keep the older
+          -# combined picker until the dual selector is back-ported.
+          - if v2_plus
+            = partial "partials/locale_nav", locals: { language_code: language_code, current_version: current_version }
+          - else
+            %button.locales-toggle{ type: "button", "aria-expanded": "false", "aria-controls": "language-select", "aria-label": "Show language menu", title: "Pick one of the #{$language_count} translations" }
+            %label{ for: "language-select", title: "Pick one of the #{$language_count} translations" }
+              %span.locales-text= "Languages (#{$languages.count}):"
+            %select{ name: "language", id: "language-select", "aria-label": "Choose a language" }
+              - $languages.each do |language|
+                - version = exposed_version_for(language.first)
+                - if version
+                  - selected = language_code == language.first
+                  -# Show only major.minor (we don't ship patch releases); the URL keeps the full version.
+                  - display_version = version.split(".").first(2).join(".")
+                  - label = "#{display_version} #{language.last[:name]}"
+                  %option{ selected: selected, label: label, value: "#{language.first}/#{version}/" }
+                    = label
         - if v2_plus
           %div.theme-switch{ role: "group", "aria-label": "Color theme" }
             %button.theme-btn{ type: "button", "data-set-theme": "system", "aria-pressed": "true", "aria-label": "Match system theme", title: "System theme" }

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -94,25 +94,11 @@
           %span.mark{ role: "img", "aria-label": "Keep a Changelog" }
           %span.header-title{ "aria-hidden": "true" } Keep a Changelog
         %nav.locales{ role: "navigation" }
-          -# v2 ships separate version + language selectors that expose every
-          -# version for every language (issue #719). Legacy pages keep the older
-          -# combined picker until the dual selector is back-ported.
-          - if v2_plus
-            = partial "partials/locale_nav", locals: { language_code: language_code, current_version: current_version }
-          - else
-            %button.locales-toggle{ type: "button", "aria-expanded": "false", "aria-controls": "language-select", "aria-label": "Show language menu", title: "Pick one of the #{$language_count} translations" }
-            %label{ for: "language-select", title: "Pick one of the #{$language_count} translations" }
-              %span.locales-text= "Languages (#{$languages.count}):"
-            %select{ name: "language", id: "language-select", "aria-label": "Choose a language" }
-              - $languages.each do |language|
-                - version = exposed_version_for(language.first)
-                - if version
-                  - selected = language_code == language.first
-                  -# Show only major.minor (we don't ship patch releases); the URL keeps the full version.
-                  - display_version = version.split(".").first(2).join(".")
-                  - label = "#{display_version} #{language.last[:name]}"
-                  %option{ selected: selected, label: label, value: "#{language.first}/#{version}/" }
-                    = label
+          -# Version + language selectors on every version (issue #719). The shared
+          -# v2 partial is design-agnostic markup; the older designs style the two
+          -# selects in their own stylesheets and drop the narrow-screen toggle,
+          -# which is a v2-only affordance.
+          = partial "partials/locale_nav", locals: { language_code: language_code, current_version: current_version }
         - if v2_plus
           %div.theme-switch{ role: "group", "aria-label": "Color theme" }
             %button.theme-btn{ type: "button", "data-set-theme": "system", "aria-pressed": "true", "aria-label": "Match system theme", title: "System theme" }

--- a/source/missing.html.haml
+++ b/source/missing.html.haml
@@ -1,0 +1,87 @@
+---
+layout: false
+title: Keep a Changelog
+description: This version hasn't been translated into this language yet.
+---
+-# Interstitial for a (language, version) pair we don't have a translation for.
+-# Generated as a proxy for every missing combination in config.rb, so the
+-# version/language selectors can offer every version for every language and any
+-# gap lands here with an explanation instead of a 404 (issue #719). The proxy
+-# passes `language_code` and `version` as locals.
+- lang_name = language_name(language_code)
+- pretty = display_version(version)
+- rtl = %w[ar fa].include?(language_code) && Gem::Version.new(version) >= Gem::Version.new("2.0.0")
+- newest_local = exposed_version_for(language_code)
+- repo = "https://github.com/olivierlacan/keep-a-changelog"
+!!! 5
+%html{ lang: language_code, dir: (rtl ? "rtl" : "ltr") }
+  %head
+    %meta{ charset: "utf-8" }
+    %meta{ content: "IE=edge", "http-equiv" => "X-UA-Compatible" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }
+    %meta{ name: "description", content: current_page.data.description }
+    %meta{ name: "robots", content: "noindex,follow" }
+    -# Apply a saved theme before first paint to avoid a flash of the wrong one.
+    :javascript
+      (function(){try{var t=localStorage.getItem('kac-theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();
+    %link{ rel: "shortcut icon", type: "image/x-icon", href: image_path("favicon.ico") }
+    %title= "Keep a Changelog #{pretty} — #{lang_name}"
+    %link{ rel: "preconnect", href: "https://fonts.googleapis.com" }
+    %link{ rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: true }
+    - font_href = "//fonts.googleapis.com/css?family=Muli:400,700|Source+Code+Pro:400,700&display=swap"
+    %link{ rel: "stylesheet", href: font_href, media: "print", onload: "this.media='all'" }
+    %noscript
+      %link{ rel: "stylesheet", href: font_href }
+    = stylesheet_link_tag "v2"
+    = javascript_include_tag "all", defer: true
+
+  %body.missing-page
+    %a.skip-link{ href: "#main" } Skip to content
+    %article
+      %header{ role: "banner" }
+        %span.mark{ role: "img", "aria-label": "Keep a Changelog" }
+        %span.header-title Keep a Changelog
+        %nav.locales{ role: "navigation" }
+          = partial "partials/locale_nav", locals: { language_code: language_code, current_version: version }
+        %div.theme-switch{ role: "group", "aria-label": "Color theme" }
+          %button.theme-btn{ type: "button", "data-set-theme": "system", "aria-pressed": "true", "aria-label": "Match system theme", title: "System theme" }
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="2"/><path d="M12 3a9 9 0 0 0 0 18z"/></svg>
+          %button.theme-btn{ type: "button", "data-set-theme": "light", "aria-pressed": "false", "aria-label": "Light theme", title: "Light theme" }
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true" focusable="false"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+          %button.theme-btn{ type: "button", "data-set-theme": "dark", "aria-pressed": "false", "aria-label": "Dark theme", title: "Dark theme" }
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+
+      .main#main{ role: "main", tabindex: "-1" }
+        %section.missing
+          %p.missing-eyebrow Translation missing
+          %h1.missing-title
+            Keep a Changelog #{pretty} isn’t available in #{lang_name} yet
+          %p.missing-lede
+            Version #{pretty} of the specification hasn’t been translated into
+            #{lang_name} so far. Here’s what you can do in the meantime.
+
+          %ul.missing-actions
+            - if version_available?("en", version)
+              %li
+                = link_to "Read version #{pretty} in English", "/en/#{version}/"
+            - if newest_local
+              %li
+                = link_to "Read the latest #{lang_name} translation (#{display_version(newest_local)})", "/#{language_code}/#{newest_local}/"
+            %li
+              = link_to "Help translate this version", "#{repo}/issues"
+
+          .missing-contribute
+            %h2 Contribute the #{lang_name} translation
+            %p
+              != "Translations live in the #{link_to "Keep a Changelog repository", repo}. To add #{lang_name} for version #{pretty}, copy the English source at <code>source/en/#{version}/</code> to <code>source/#{language_code}/#{version}/</code> and translate its contents, then #{link_to "open a pull request", "#{repo}/pulls"} or #{link_to "start by filing an issue", "#{repo}/issues/new"}."
+            %p.missing-meta
+              See
+              = link_to "the contribution guide", "#{repo}/blob/main/CONTRIBUTING.md"
+              and
+              = link_to "current translation coverage", "#{repo}/blob/main/TRANSLATION_COVERAGE.md"
+              for details.
+
+      %footer.footer.clearfix{ role: "contentinfo" }
+        = image_tag "keep-a-changelog-badge.svg", width: 140, height: 140, class: "badge", alt: "Keep a Changelog badge, designed by Tyler Fortune"
+        %p.about
+          != "Keep a Changelog is #{link_to 'MIT licensed', 'https://choosealicense.com/licenses/mit/'}, #{link_to 'created and maintained', repo} by #{link_to 'Olivier Lacan', 'https://olivierlacan.com/'}, and designed by Tyler Fortune."

--- a/source/missing.html.haml
+++ b/source/missing.html.haml
@@ -71,10 +71,7 @@ description: This version hasn't been translated into this language yet.
             %h2= t.("contribute_title") % vars
             - guide = link_to(t.("guide_label"), "#{repo}/blob/main/CONTRIBUTING.md")
             - coverage = link_to(t.("coverage_label"), "#{repo}/blob/main/TRANSLATION_COVERAGE.md")
-            - pr = link_to(t.("pr_label"), "#{repo}/pulls")
-            - issue = link_to(t.("issue_label"), "#{repo}/issues/new")
             %p!= t.("contribute_body") % vars.merge(guide: guide, coverage: coverage)
-            %p.missing-meta!= t.("cta") % { pr: pr, issue: issue }
 
       %footer.footer.clearfix{ role: "contentinfo" }
         = image_tag "keep-a-changelog-badge.svg", width: 140, height: 140, class: "badge", alt: "Keep a Changelog badge, designed by Tyler Fortune"

--- a/source/missing.html.haml
+++ b/source/missing.html.haml
@@ -13,6 +13,9 @@ description: This version hasn't been translated into this language yet.
 - rtl = %w[ar fa].include?(language_code) && Gem::Version.new(version) >= Gem::Version.new("2.0.0")
 - newest_local = exposed_version_for(language_code)
 - repo = "https://github.com/olivierlacan/keep-a-changelog"
+-# Localized interstitial copy for language_code, falling back to English per key.
+- t = ->(key) { interstitial_string(language_code, key) }
+- vars = { version: pretty, language: lang_name }
 !!! 5
 %html{ lang: language_code, dir: (rtl ? "rtl" : "ltr") }
   %head
@@ -53,33 +56,25 @@ description: This version hasn't been translated into this language yet.
 
       .main#main{ role: "main", tabindex: "-1" }
         %section.missing
-          %p.missing-eyebrow Translation missing
-          %h1.missing-title
-            Keep a Changelog #{pretty} isn’t available in #{lang_name} yet
-          %p.missing-lede
-            Version #{pretty} of the specification hasn’t been translated into
-            #{lang_name} so far. Here’s what you can do in the meantime.
+          %h1.missing-title= t.("title") % vars
+          %p.missing-lede= t.("lede") % vars
 
           %ul.missing-actions
             - if version_available?("en", version)
               %li
-                = link_to "Read version #{pretty} in English", "/en/#{version}/"
+                = link_to t.("read_english") % vars, "/en/#{version}/"
             - if newest_local
               %li
-                = link_to "Read the latest #{lang_name} translation (#{display_version(newest_local)})", "/#{language_code}/#{newest_local}/"
-            %li
-              = link_to "Help translate this version", "#{repo}/issues"
+                = link_to t.("read_latest") % vars.merge(latest: display_version(newest_local)), "/#{language_code}/#{newest_local}/"
 
           .missing-contribute
-            %h2 Contribute the #{lang_name} translation
-            %p
-              != "Translations live in the #{link_to "Keep a Changelog repository", repo}. To add #{lang_name} for version #{pretty}, copy the English source at <code>source/en/#{version}/</code> to <code>source/#{language_code}/#{version}/</code> and translate its contents, then #{link_to "open a pull request", "#{repo}/pulls"} or #{link_to "start by filing an issue", "#{repo}/issues/new"}."
-            %p.missing-meta
-              See
-              = link_to "the contribution guide", "#{repo}/blob/main/CONTRIBUTING.md"
-              and
-              = link_to "current translation coverage", "#{repo}/blob/main/TRANSLATION_COVERAGE.md"
-              for details.
+            %h2= t.("contribute_title") % vars
+            - guide = link_to(t.("guide_label"), "#{repo}/blob/main/CONTRIBUTING.md")
+            - coverage = link_to(t.("coverage_label"), "#{repo}/blob/main/TRANSLATION_COVERAGE.md")
+            - pr = link_to(t.("pr_label"), "#{repo}/pulls")
+            - issue = link_to(t.("issue_label"), "#{repo}/issues/new")
+            %p!= t.("contribute_body") % vars.merge(guide: guide, coverage: coverage)
+            %p.missing-meta!= t.("cta") % { pr: pr, issue: issue }
 
       %footer.footer.clearfix{ role: "contentinfo" }
         = image_tag "keep-a-changelog-badge.svg", width: 140, height: 140, class: "badge", alt: "Keep a Changelog badge, designed by Tyler Fortune"

--- a/source/partials/_locale_nav.html.haml
+++ b/source/partials/_locale_nav.html.haml
@@ -4,8 +4,8 @@
 -#   language_code   — the language being viewed (e.g. "fr")
 -#   current_version — the spec version being viewed (e.g. "1.1.0")
 -#
--# Both selectors list the full grid and mark combinations we don't have yet as
--# "not translated" rather than hiding them: a version pick keeps your language
+-# Both selectors list the full grid and tag combinations we don't have yet with
+-# a compact "(n/a)" rather than hiding them: a version pick keeps your language
 -# fixed, a language pick keeps your version fixed, and either way an option we
 -# can't satisfy resolves to a generated interstitial that explains the gap.
 %button.locales-toggle{ type: "button", "aria-expanded": "false", "aria-controls": "locale-fields", "aria-label": "Show version and language menu", title: "Choose a version or translation" }
@@ -16,8 +16,12 @@
     %select.locale-select{ name: "version", id: "version-select", "aria-label": "Choose a version" }
       - selectable_versions.reverse_each do |v|
         - available = version_available?(language_code, v)
-        - label = available ? display_version(v) : "#{display_version(v)} — not translated"
-        %option{ value: "#{language_code}/#{v}/", selected: (v == current_version), label: label, "data-available": available.to_s }
+        -# Untranslated versions stay selectable (picking one lands on the
+        -# interstitial that explains the gap); a compact "(n/a)" tag marks them
+        -# instead of a full sentence, with the detail in the option's tooltip.
+        - label = available ? display_version(v) : "#{display_version(v)} (n/a)"
+        - hint = available ? nil : "Version #{display_version(v)} isn’t translated into #{language_name(language_code)} yet"
+        %option{ value: "#{language_code}/#{v}/", selected: (v == current_version), label: label, title: hint, "data-available": available.to_s }
           = label
 
   %label.locale-field{ for: "language-select" }
@@ -25,6 +29,7 @@
     %select.locale-select{ name: "language", id: "language-select", "aria-label": "Choose a language" }
       - $languages.each do |code, meta|
         - available = version_available?(code, current_version)
-        - label = available ? meta[:name] : "#{meta[:name]} — #{display_version(current_version)} not translated"
-        %option{ value: "#{code}/#{current_version}/", selected: (code == language_code), label: label, "data-available": available.to_s }
+        - label = available ? meta[:name] : "#{meta[:name]} (n/a)"
+        - hint = available ? nil : "#{meta[:name]} doesn’t have version #{display_version(current_version)} yet"
+        %option{ value: "#{code}/#{current_version}/", selected: (code == language_code), label: label, title: hint, "data-available": available.to_s }
           = label

--- a/source/partials/_locale_nav.html.haml
+++ b/source/partials/_locale_nav.html.haml
@@ -1,0 +1,30 @@
+-# Version + language selectors (v2). Rendered inside a %nav.locales wrapper by
+-# both the page layout and the missing-translation interstitial, so it receives
+-# the current page's coordinates explicitly:
+-#   language_code   — the language being viewed (e.g. "fr")
+-#   current_version — the spec version being viewed (e.g. "1.1.0")
+-#
+-# Both selectors list the full grid and mark combinations we don't have yet as
+-# "not translated" rather than hiding them: a version pick keeps your language
+-# fixed, a language pick keeps your version fixed, and either way an option we
+-# can't satisfy resolves to a generated interstitial that explains the gap.
+%button.locales-toggle{ type: "button", "aria-expanded": "false", "aria-controls": "locale-fields", "aria-label": "Show version and language menu", title: "Choose a version or translation" }
+
+.locale-fields#locale-fields
+  %label.locale-field{ for: "version-select" }
+    %span.locales-text Version:
+    %select.locale-select{ name: "version", id: "version-select", "aria-label": "Choose a version" }
+      - selectable_versions.reverse_each do |v|
+        - available = version_available?(language_code, v)
+        - label = available ? display_version(v) : "#{display_version(v)} — not translated"
+        %option{ value: "#{language_code}/#{v}/", selected: (v == current_version), label: label, "data-available": available.to_s }
+          = label
+
+  %label.locale-field{ for: "language-select" }
+    %span.locales-text= "Language (#{$languages.count}):"
+    %select.locale-select{ name: "language", id: "language-select", "aria-label": "Choose a language" }
+      - $languages.each do |code, meta|
+        - available = version_available?(code, current_version)
+        - label = available ? meta[:name] : "#{meta[:name]} — #{display_version(current_version)} not translated"
+        %option{ value: "#{code}/#{current_version}/", selected: (code == language_code), label: label, "data-available": available.to_s }
+          = label


### PR DESCRIPTION
Addresses #719. Splits the single combined picker into separate **Version** and **Language** selectors, makes every missing `(language, version)` combination resolve to a helpful, **localized** interstitial instead of a 404, and brings the selectors to **every design era** (0.3.0 → 2.0). Also picks up CSS linting and a Ruby 3.4 dependency fix along the way.

## Why

The old dropdown is really a language picker that pins each language to its newest translated version, so there's no UI to reach an older version, and viewing e.g. `/en/1.0.0/` still shows "1.1 English" selected — the "too much and too little at once" confusion in #719. Versions are also sparse per language (2.0.0 currently exists only in English), so any selector has to say something sensible about the gaps.

## What changed

### Selectors
- **Two selectors** (`source/partials/_locale_nav.html.haml`) list the full grid. A version pick keeps your language fixed; a language pick keeps your version fixed. Combinations we don't have are tagged `(n/a)` rather than hidden, so the state is visible before you click — and the current page's *actual* version is what's selected (the direct #719 fix).
- **On every design, not just v2.** The shared partial now renders on 1.0.0/1.1.0 (`application.css`) and 0.3.0 (`legacy.css`) too, styled per era with the v2-only narrow-screen toggle hidden. The nav JS already navigates generically off `.locales select`, so no JS change was needed. This brings the accessible dual selectors to the older designs without reskinning them — we deliberately did **not** migrate old versions to v2.

### Interstitials
- Every untranslated combo is generated as a real page (`source/missing.html.haml`) explaining the gap, with *read this version in English*, *read the latest translation this language does have*, and *contribute* actions. Typing an untranslated URL like `/fr/2.0.0/` lands here instead of 404ing; picking an `(n/a)` option from any page routes here too.
- **Localized** (replaces the original PR's "English-only, follow-up later" note). Copy is presented in the requested language — strings live in `data/interstitial.yml` keyed by language code, resolved by an `interstitial_string` helper with English as the per-key fallback. 21 languages are seeded (22 counting English); the six most inflection-sensitive (Georgian, Farsi, Croatian, Slovenian, Serbian, Slovak) fall back to English until a human provides them.
- **Streamlined & tightened.** Dropped the redundant eyebrow, the Help-translate button, and the "open a PR / file an issue" line (the contribution-guide link in the body covers it), trimmed the lede, and pulled the vertical rhythm in (~30% shorter): the two read buttons sit side by side and the contribute box padding is reduced. The page heading uses a wider measure than the body so it stays on one line, and the contribute heading falls back to `text-wrap: balance` so it no longer overflows on mobile. One interstitial design serves all versions (a 1.1 gap shows the version-aware v2 interstitial) — we chose not to fork it per era.

### config.rb
- Helpers for which spec versions exist per language, proxy generation for the missing combos, and the interstitial-string lookup. Exposure mirrors the existing rule — drafts show when serving locally, capped at the published `$last_version` in a production build (so 2.0.0 interstitials aren't shipped until release).

### Tooling & housekeeping
- **CSS linting**: stylelint + `stylelint-config-standard` for correctness (duplicate selectors/properties, redundant longhands, invalid values), with the stylistic opinions that fight this file's deliberate hand-authored style switched off and documented in `.stylelintrc.cjs`. Adds `npm run lint:css` and a `css-lint` CI workflow that fails on violations; the two real issues it flagged are fixed.
- **Ruby 3.4 readiness**: declared `base64`, `bigdecimal`, `csv`, and `mutex_m` in the Gemfile — undeclared transitive requirements of `activesupport`/`em-websocket`/`tilt` that Ruby 3.4 drops from the default gems (also clears the boot-time deprecation warnings on 3.3).

## Verification

- Production build succeeds; version selectors correctly capped at the published `$last_version` (no unpublished 2.0.0 in the pickers); interstitials generated for the right gaps.
- Selectors verified rendering and navigating on 0.3.0, 1.0.0, 1.1.0, and 2.0.0, including routing an `(n/a)` pick to the version-aware interstitial.
- Interstitial localization verified across seeded languages and the English fallback; heading-wrap behavior measured across viewport widths.
- CSS lint passes; server boots with zero deprecation warnings.

## Notes / follow-ups

- **Translation review**: the 21 seeded languages in `data/interstitial.yml` are machine-adapted and ship as authoritative copy — worth an editorial pass. Watch especially the apposition workaround for inflected languages (e.g. Czech "v jazyce Čeština", Russian/Ukrainian "мовою …"), the Korean "은(는)" particle after the version number, and the German compounds / CJK phrasing.
- **Reskinning old versions to the v2 design** is intentionally deferred; the nav is now unified, so if that's ever done it's only about the spec-page body structure.
- Visual-regression snapshots (`test/visual/`) are a gitignored local before/after tool, not a CI gate; baselines were regenerated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

