### PR TITLE
Add contributor guidance and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,44 @@ is in [CONTRIBUTING.md](CONTRIBUTING.md)). Protect that: any change to how
 pages are structured or versioned must remain easy for a non-programmer
 translator to follow.
 
+## How we use LLMs
+
+Keep a Changelog has one maintainer and myriad contributors. Keeping a free
+open source project like this alive involves complicated logistics: dozens of
+languages, several spec versions in each, and a steady stream of contributions
+to review. That work does not happen without automation — and even automation
+requires maintenance. LLMs help carry that load, within strict limits, because
+wasting resources is antithetical to what this project stands for.
+
+LLMs are **not** used to:
+
+- **Replace translators.** Translations are created and reviewed by people who
+  speak the language and know the culture. No model output can substitute for
+  that judgment.
+- **Decide what Keep a Changelog says.** The guidelines are human positions,
+  reasoned about and owned by humans.
+- **Spend tokens on needless features.** If a feature would not exist without
+  an LLM to justify it, it should not exist.
+
+LLMs **are** used to:
+
+- **Build reusable tools that do not need an LLM to run.** The translation
+  coverage lint, the semantic QA pipeline, and the version routing tests are
+  ordinary scripts anyone can run, offline, for free, forever. An LLM may help
+  write a tool once; the tool must then stand on its own.
+- **Validate accessibility, design, and functionality requirements** — checks
+  a single maintainer could not perform by hand across every language, version,
+  and browser.
+
+The most daunting recurring problem this addresses is translation upkeep.
+Every version-specific translation must:
+
+1. exist — or the site must give clear guidance for contributing one;
+2. be accurate and consistent with the original English guidelines, while
+   remaining understandable in its own language and culture.
+
+Tooling helps check these. Humans decide them.
+
 ## Writing and content
 
 The content is held to `docs/tone-and-voice.md`. In short: write plainly,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,11 @@
 # Working on Keep a Changelog
 
-Guidance for coding agents and new contributors. It explains how this project
-is built and, more importantly, why. When a change conflicts with these
-principles, the principles win.
+This file explains why the project is built the way it is. When a change
+conflicts with these principles, the principles win.
+
+How-to guidance — setup, common tasks, and the translation workflow — lives
+exclusively in [CONTRIBUTING.md](CONTRIBUTING.md). Do not repeat it here;
+point to it instead.
 
 ## What this project is
 
@@ -28,12 +31,12 @@ anything that requires a server, a database, or a build service beyond the
 existing static build.
 
 **Ruby at heart, CLI-based.** This is a Ruby project (Middleman, Rake,
-Minitest). Workflows run from the command line: `bin/rake serve`,
-`bin/rake build`, `bin/rake test`. Prefer extending the existing Ruby and
-Rake tooling over adding new toolchains. Small exceptions exist where a tool
-is clearly the right one for the job (Playwright for cross-browser visual
-regression, a Python script for translation QA scoring) — they are dev-only
-and never part of the shipped site.
+Minitest), and every workflow runs from the command line ([CONTRIBUTING.md](CONTRIBUTING.md)
+lists the tasks). Prefer extending the existing Ruby and Rake tooling over
+adding new toolchains. Small exceptions exist where a tool is clearly the
+right one for the job (Playwright for cross-browser visual regression, a
+Python script for translation QA scoring) — they are dev-only and never part
+of the shipped site.
 
 **Boring is fine.** We do not need the most hyped language or framework.
 The measure of a tool is whether the project is hindered without it, not
@@ -43,11 +46,10 @@ what problem it solves that the current setup cannot.
 **Translations are a first-class concern.** The site's incredible number of
 community-created translations exists because translating and managing
 versions is deliberately accessible — to readers and to contributors. A
-translation is a directory under `source/` named after its language code,
-containing plain markup a translator can edit without understanding the build.
-Protect that: any change to how pages are structured or versioned must remain
-easy for a non-programmer translator to follow. Translation checks live in
-`bin/rake translations:lint` and `bin/rake translations:qa`.
+translator can edit plain markup without understanding the build (the workflow
+is in [CONTRIBUTING.md](CONTRIBUTING.md)). Protect that: any change to how
+pages are structured or versioned must remain easy for a non-programmer
+translator to follow.
 
 ## Writing and content
 
@@ -60,13 +62,3 @@ documentation and commit messages too.
 Guidelines on the site should explain their reasoning. A reader should be able
 to disagree intelligently with any recommendation we make, because we told
 them why we make it.
-
-## Practical notes
-
-- `bin/rake serve` — local dev server with live reload at localhost:4567
-- `bin/rake build` — build the static site into `build/`
-- `bin/rake test` — run the Minitest suite (also the default task)
-- `bin/rake translations:lint` — rule-based translation lint
-- `bundle exec standardrb` — Ruby style (Standard)
-- Site source lives in `source/`, one directory per language, one directory
-  per spec version inside each language.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,72 @@
+# Working on Keep a Changelog
+
+Guidance for coding agents and new contributors. It explains how this project
+is built and, more importantly, why. When a change conflicts with these
+principles, the principles win.
+
+## What this project is
+
+Keep a Changelog is a set of mindful guidelines for human-centered change
+communication. It is not a spec for people to robotically validate against.
+The site exists to help people communicate software changes to other humans,
+and every decision — in the writing and in the code — serves that goal.
+
+The project has one maintainer, myriad contributors, and an oversized impact
+on how software changes are communicated around the world. Most of that impact
+comes from refusing easy tropes: we do not create or endorse specific tools,
+we do not follow conventions blindly when they make little sense, and we do
+not tell people what to do without regard for their specific contexts.
+
+Apply the same judgment to the project itself. Favor simplicity, and when a
+rule needs to be strict, make the reasoning for that strictness clear.
+
+## Technical principles
+
+**No backend.** The site is static HTML, built once and served from GitHub
+Pages. This keeps hosting simple, cheap, and durable. Do not introduce
+anything that requires a server, a database, or a build service beyond the
+existing static build.
+
+**Ruby at heart, CLI-based.** This is a Ruby project (Middleman, Rake,
+Minitest). Workflows run from the command line: `bin/rake serve`,
+`bin/rake build`, `bin/rake test`. Prefer extending the existing Ruby and
+Rake tooling over adding new toolchains. Small exceptions exist where a tool
+is clearly the right one for the job (Playwright for cross-browser visual
+regression, a Python script for translation QA scoring) — they are dev-only
+and never part of the shipped site.
+
+**Boring is fine.** We do not need the most hyped language or framework.
+The measure of a tool is whether the project is hindered without it, not
+whether it is popular. Before proposing a migration or a new dependency, ask
+what problem it solves that the current setup cannot.
+
+**Translations are a first-class concern.** The site's incredible number of
+community-created translations exists because translating and managing
+versions is deliberately accessible — to readers and to contributors. A
+translation is a directory under `source/` named after its language code,
+containing plain markup a translator can edit without understanding the build.
+Protect that: any change to how pages are structured or versioned must remain
+easy for a non-programmer translator to follow. Translation checks live in
+`bin/rake translations:lint` and `bin/rake translations:qa`.
+
+## Writing and content
+
+The content is held to `docs/tone-and-voice.md`. In short: write plainly,
+lead with the point, don't gatekeep, and prefer wording a non-native reader
+can understand on the first pass and a translator can translate rather than
+rephrase. This applies to site content, and it is a good default for
+documentation and commit messages too.
+
+Guidelines on the site should explain their reasoning. A reader should be able
+to disagree intelligently with any recommendation we make, because we told
+them why we make it.
+
+## Practical notes
+
+- `bin/rake serve` — local dev server with live reload at localhost:4567
+- `bin/rake build` — build the static site into `build/`
+- `bin/rake test` — run the Minitest suite (also the default task)
+- `bin/rake translations:lint` — rule-based translation lint
+- `bundle exec standardrb` — Ruby style (Standard)
+- Site source lives in `source/`, one directory per language, one directory
+  per spec version inside each language.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,13 @@ few native speakers of the language you're translating to in the Pull Request
 comments. They'll help review your translation for simple mistakes and give us
 a better idea of whether your translation is accurate.
 
+Translations are human work. This project does not use LLMs to replace
+translators, and a translation needs your judgment about what reads naturally
+in your language and culture — not just what matches the English words. The
+automated checks below only help find gaps and inconsistencies; they don't
+write or approve translations. [AGENTS.md](AGENTS.md) explains how the project
+uses LLMs and where it draws the line.
+
 ### Translation checks
 
 - `ruby translation_coverage.rb` reports how complete each translation is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,77 @@
-See [README](README.md#development).
+# Contributing to Keep a Changelog
+
+Please do contribute! Issues and pull requests are welcome. This file is the
+single home for contributor guidance — how to set up the project, work on it,
+and submit changes. For the principles behind how the project is built, see
+[AGENTS.md](AGENTS.md).
+
+## Development
+
+### Dependencies
+
+- Ruby ([see version][ruby-version], [rbenv][rbenv] recommended)
+- Bundler (`gem install bundler`)
+
+### Installation
+
+- `git clone https://github.com/olivierlacan/keep-a-changelog.git`
+- `cd keep-a-changelog`
+- `bundle install`
+
+### Common tasks
+
+- `bin/rake serve` starts a local development server at http://localhost:4567
+  which will reload with any local file changes
+- `bin/rake build` runs middleman build with `--verbose` flag so build errors are
+  logged for easier debugging
+- `bin/rake test` runs the Minitest suite (also the default task)
+- `bundle exec standardrb` checks Ruby style ([Standard][standard])
+
+### Visual regression tests
+
+Cross-browser screenshot tests (Playwright, dev-only; not shipped with the
+site) guard against unintended visual changes:
+
+- `bin/rake snapshots:baseline` builds the site and records baseline screenshots
+- `bin/rake snapshots:check` rebuilds and diffs against the baseline
+
+### Deployment
+
+- `bin/rake clean` can clean a corrupted `build/` directory in
+  case `publish` failed
+- `bin/rake deploy` cleans, builds and pushes to the `gh-pages` branch on GitHub so
+  the site is deployed to keepachangelog.com
+
+## Translations
+
+Create a new directory in [`source/`][source] named after the ISO 639-1 code
+for the language you wish to translate Keep a Changelog to. For example,
+assuming you want to translate to French Canadian:
+
+- create the `source/fr-CA` directory.
+- duplicate the `source/en/1.0.0/index.html.haml` file in `source/fr-CA`.
+- edit `source/fr-CA/1.0.0/index.html.haml` until your translation is ready.
+- commit your changes to your own [fork][fork]
+- submit a [Pull Request][pull-request] with your changes
+
+It may take some time to review your submitted Pull Request. Try to involve a
+few native speakers of the language you're translating to in the Pull Request
+comments. They'll help review your translation for simple mistakes and give us
+a better idea of whether your translation is accurate.
+
+### Translation checks
+
+- `ruby translation_coverage.rb` reports how complete each translation is
+  (see [TRANSLATION_COVERAGE.md](TRANSLATION_COVERAGE.md))
+- `bin/rake translations:lint` runs a deterministic, rule-based translation lint
+- `bin/rake translations:qa` scores translated segments semantically
+  (one-time setup: `bin/rake translations:setup`)
+
+Thank you for your help improving software one changelog at a time!
+
+[rbenv]: https://github.com/rbenv/rbenv
+[ruby-version]: .ruby-version
+[source]: source/
+[standard]: https://github.com/standardrb/standard
+[pull-request]: https://help.github.com/articles/creating-a-pull-request/
+[fork]: https://help.github.com/articles/fork-a-repo/

--- a/README.md
+++ b/README.md
@@ -6,60 +6,17 @@ Don’t let your friends dump git logs into changelogs™
 
 This repository generates https://keepachangelog.com/.
 
-## Development
-
-### Dependencies
-
-- Ruby ([see version][ruby-version], [rbenv][rbenv] recommended)
-- Bundler (`gem install bundler`)
-
-### Installation
-
-- `git clone https://github.com/olivierlacan/keep-a-changelog.git`
-- `cd keep-a-changelog`
-- `bundle install`
-- `bin/rake serve` starts a local development server at http://localhost:4567
-  which will reload with any local file changes
-- `bin/rake build` runs middleman build with `--verbose` flag so build errors are 
-  logged for easier debugging
-
-### Deployment
-
-- `bin/rake clean` can clean a corrupted `build/` directory in 
-  case `publish` failed
-- `bin/rake deploy` cleans, builds and pushes to the `gh-pages` branch on GitHub so 
-  the site is deployed to keepachangelog.com
-
-### Translations
-
-Create a new directory in [`source/`][source] named after the ISO 639-1 code
-for the language you wish to translate Keep a Changelog to. For example,
-assuming you want to translate to French Canadian:
-
-- create the `source/fr-CA` directory.
-- duplicate the `source/en/1.0.0/index.html.haml` file in `source/fr-CA`.
-- edit `source/fr-CA/1.0.0/index.html.haml` until your translation is ready.
-- commit your changes to your own [fork][fork]
-- submit a [Pull Request][pull-request] with your changes
-
-It may take some time to review your submitted Pull Request. Try to involve a
-few native speakers of the language you're translating to in the Pull Request
-comments. They'll help review your translation for simple mistakes and give us
-a better idea of whether your translation is accurate.
-
 ## Contribute
 
 Please do contribute! Issues and pull requests are welcome.
+
+Development setup, common tasks, and the translation workflow are documented
+in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Thank you for your help improving software one changelog at a time!
 
 [changelog]: ./CHANGELOG.md
 [changelog-badge]: https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.1.0-%23E05735
 [license]: ./LICENSE
-[rbenv]: https://github.com/rbenv/rbenv
-[ruby-version]: .ruby-version
-[source]: source/
-[pull-request]: https://help.github.com/articles/creating-a-pull-request/
-[fork]: https://help.github.com/articles/fork-a-repo/
 [version-badge]: https://img.shields.io/badge/version-1.1.0-blue.svg
 [license-badge]: https://img.shields.io/badge/license-MIT-blue.svg


### PR DESCRIPTION
## Summary
This PR adds documentation to guide contributors and coding agents working on the Keep a Changelog project. It establishes clear principles for how the project should be maintained and evolved.

## Changes
- **AGENTS.md**: Comprehensive guide covering the project's philosophy, technical principles, and practical workflows
  - Explains the project's human-centered mission and decision-making philosophy
  - Documents technical constraints: static site, Ruby/CLI-based tooling, no backend requirements
  - Establishes translation accessibility as a first-class concern
  - Provides writing guidelines aligned with tone and voice standards
  - Lists common development commands and project structure

- **CLAUDE.md**: Reference file pointing to AGENTS.md for agent context

## Details
The AGENTS.md document serves as a constitution for the project, making explicit the reasoning behind architectural decisions (no backend, Ruby at heart, boring-is-fine approach) and content standards (plain language, accessible to translators, reasoning-forward guidelines). This ensures contributors and agents understand not just what to do, but why those decisions matter to the project's core mission of human-centered change communication.

https://claude.ai/code/session_016ML6Rb5q4UDidu1mTZ4gUv