### PR TITLE
Pin each spec page's example changelog to its own era

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Version-pinned example changelog: once a newer spec version is published,
+  each older version's page shows this changelog as it stood at that track's
+  last release, derived at build time from this file.
+
 ## [2.0.0] - 2026-06-07
 
 2.0.0 is the first major revision of Keep a Changelog. It breaks the guidance,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Fixed
 
-- Version-pinned example changelog: once a newer spec version is published,
-  each older version's page shows this changelog as it stood at that track's
-  last release, derived at build time from this file.
+- Older spec pages no longer display an example changelog written to newer
+  conventions than the page describes: each page's example is now pinned to
+  its own version's last release, derived at build time from this file.
 
 ## [2.0.0] - 2026-06-07
 

--- a/config.rb
+++ b/config.rb
@@ -261,25 +261,31 @@ helpers do
   end
 
   # Should +version+'s page show the pinned (historical) example changelog
-  # rather than the live one? Only spec versions older than the published
-  # latest, and only when the changelog has a release on that version's
-  # major.minor track to pin to.
+  # rather than the live one? Only when the changelog already documents a
+  # release on a newer major.minor track than the page's, and the page's own
+  # track has a release to pin to.
   def changelog_example_pinned?(version)
     return false unless version
-    return false unless ChangelogPin.pinned?(version, last_version: $last_version)
-    !ChangelogPin.track_release(File.read("CHANGELOG.md"), version).nil?
+    text = File.read("CHANGELOG.md")
+    ChangelogPin.pinned?(text, version) && !ChangelogPin.track_release(text, version).nil?
   end
 
-  # The project's own CHANGELOG, shown as the hero example. Pages for spec
-  # versions older than the published latest get a view pinned to their track's
-  # last release (see tools/changelog_pin.rb) so the example always matches the
-  # conventions the page describes. Soft line wraps in the
+  # The project's own CHANGELOG, the example every spec page embeds. Pages for
+  # spec versions older than the newest track the changelog documents get a
+  # view pinned to their own track's last release (see tools/changelog_pin.rb)
+  # so the example always matches the conventions the page describes. Raw
+  # markdown, hard wraps preserved — what the pre-2.0 pages render directly.
+  def changelog_example(version = current_page.metadata[:page][:version])
+    text = File.read("CHANGELOG.md")
+    changelog_example_pinned?(version) ? ChangelogPin.pin(text, version) : text
+  end
+
+  # The example changelog for the 2.0+ hero figure. Soft line wraps in the
   # source (manual 80-column breaks) read badly in a narrow preview, so unwrap
   # them: join hard-wrapped lines within paragraphs and list items while keeping
   # blank lines, headings, list boundaries, and code blocks intact.
   def changelog_preview(version = nil)
-    text = File.read("CHANGELOG.md")
-    text = ChangelogPin.pin(text, version) if changelog_example_pinned?(version)
+    text = changelog_example(version)
     in_code = false
     out = []
     text.each_line do |raw|

--- a/config.rb
+++ b/config.rb
@@ -7,6 +7,11 @@
 # test/version_routing_test.rb.
 require_relative "tools/version_routing"
 
+# Version pinning for the hero example changelog (which CHANGELOG.md view each
+# spec page shows) lives in a pure module for the same reason. See
+# test/changelog_pin_test.rb.
+require_relative "tools/changelog_pin"
+
 # ----- Site ----- #
 # Last version should be the latest English version since Keep a Changelog is
 # first written in English, then translated into other languages later.
@@ -255,14 +260,29 @@ helpers do
     "#{d.strftime("%B")} #{n}#{suffix}, #{d.year}"
   end
 
-  # The project's own CHANGELOG, shown as the hero example. Soft line wraps in the
+  # Should +version+'s page show the pinned (historical) example changelog
+  # rather than the live one? Only spec versions older than the published
+  # latest, and only when the changelog has a release on that version's
+  # major.minor track to pin to.
+  def changelog_example_pinned?(version)
+    return false unless version
+    return false unless ChangelogPin.pinned?(version, last_version: $last_version)
+    !ChangelogPin.track_release(File.read("CHANGELOG.md"), version).nil?
+  end
+
+  # The project's own CHANGELOG, shown as the hero example. Pages for spec
+  # versions older than the published latest get a view pinned to their track's
+  # last release (see tools/changelog_pin.rb) so the example always matches the
+  # conventions the page describes. Soft line wraps in the
   # source (manual 80-column breaks) read badly in a narrow preview, so unwrap
   # them: join hard-wrapped lines within paragraphs and list items while keeping
   # blank lines, headings, list boundaries, and code blocks intact.
-  def changelog_preview
+  def changelog_preview(version = nil)
+    text = File.read("CHANGELOG.md")
+    text = ChangelogPin.pin(text, version) if changelog_example_pinned?(version)
     in_code = false
     out = []
-    File.read("CHANGELOG.md").each_line do |raw|
+    text.each_line do |raw|
       line = raw.chomp
       if line =~ /\A\s*```/
         in_code = !in_code

--- a/docs/version-pinned-example.md
+++ b/docs/version-pinned-example.md
@@ -1,0 +1,78 @@
+# Version-pinned example changelog
+
+How each spec page's hero "Example changelog" stays true to the conventions
+that page describes, even after newer spec versions ship.
+
+## The problem
+
+The example changelog shown on every 2.0+ spec page is the project's own
+`CHANGELOG.md`, read live from the repository root at build time. The live file
+always follows the *latest* spec: its preamble links to the newest spec URL,
+and new entries adopt whatever conventions the newest spec recommends.
+
+That's exactly right for the latest version's page, but wrong for older ones.
+Once 2.1.0 or 3.0.0 ships, a visitor reading `/en/2.0.0/` would see an example
+written to conventions the page doesn't describe — a caption claiming "written
+using the conventions described below" over a changelog that isn't.
+
+## Approaches considered
+
+**Tracking branches** — a branch per minor (`2.0`, `2.1`, …) holding a
+`CHANGELOG.md` frozen to that track. Rejected: the deploy workflow builds from
+a single shallow checkout (no other branches, no tags are fetched), so the
+build can't see them without extra CI plumbing; each branch is another thing to
+maintain and forget; and copy edits to old entries on `main` would never reach
+the pinned views.
+
+**Committed snapshots** — a `changelogs/<version>.md` file frozen at each
+release. Rejected for similar reasons: it adds a release-checklist step that's
+easy to miss, duplicates content that then drifts, and every patch release on
+an old track (translation batches become patches — see
+`versioning-policy.md`) would require re-snapshotting.
+
+**Derivation (chosen)** — compute the pinned view from the one live
+`CHANGELOG.md` at build time. The changelog is append-mostly and every entry is
+dated and versioned, so "the changelog as it stood at the last 2.0.x release"
+is reconstructable from today's file.
+
+## How derivation works
+
+`tools/changelog_pin.rb` (pure, unit-tested in `test/changelog_pin_test.rb`;
+wired up through the `changelog_preview`/`changelog_example_pinned?` helpers in
+`config.rb` and the hero figure in `source/layouts/layout.html.haml`):
+
+- A page shows a pinned view only when its spec version is **older than the
+  published `$last_version`**. The latest version's page — and any newer draft
+  being previewed — keeps showing the live file, `Unreleased` section and all.
+- The pin cutoff is the **newest release on the page's major.minor track**
+  (the 2.0.0 page pins to the last 2.0.x, not to 2.0.0 itself), because patch
+  releases ship translations and site fixes without changing the spec.
+- Entries newer than the cutoff are dropped, along with their reference-link
+  definitions at the bottom of the file.
+- The `Unreleased` section keeps its heading — it's part of the format being
+  taught — but is emptied, since its contents describe work newer than the
+  track.
+- The `[unreleased]` compare link is rewritten to diff from the cutoff release,
+  and the "based on Keep a Changelog" URL in the preamble is rewritten to the
+  page's spec version.
+- The caption above the example switches to say the changelog is shown "as of
+  the last x.y release".
+
+## What this buys
+
+- `CHANGELOG.md` stays the single source of truth, the same philosophy as the
+  release tooling (`tools/changelog_release.rb`).
+- No release-time step: the moment `$last_version` moves past a version, that
+  version's page pins itself.
+- Later copy edits to old entries (typo fixes, clarified wording) still flow
+  into the pinned views, and a patch release on an old track moves that track's
+  pin forward automatically.
+
+## The trade-off
+
+A derived view is a reconstruction, not a byte-for-byte historical snapshot.
+If a future spec restructured the changelog *preamble* itself, the derived
+older views would inherit the new preamble shape (minus the rewritten spec
+URL). If that ever happens, the derivation rules in `tools/changelog_pin.rb`
+are the place to compensate — or that one version can graduate to a committed
+snapshot.

--- a/docs/version-pinned-example.md
+++ b/docs/version-pinned-example.md
@@ -5,15 +5,17 @@ that page describes, even after newer spec versions ship.
 
 ## The problem
 
-The example changelog shown on every 2.0+ spec page is the project's own
-`CHANGELOG.md`, read live from the repository root at build time. The live file
-always follows the *latest* spec: its preamble links to the newest spec URL,
-and new entries adopt whatever conventions the newest spec recommends.
+The example changelog shown on every spec page is the project's own
+`CHANGELOG.md`, read live from the repository root at build time — the 2.0+
+hero figure and the pre-2.0 header `<pre>` both embed it. The live file always
+follows the *newest* spec it documents: its preamble links to the newest spec
+URL, and new entries adopt whatever conventions that spec recommends.
 
-That's exactly right for the latest version's page, but wrong for older ones.
-Once 2.1.0 or 3.0.0 ships, a visitor reading `/en/2.0.0/` would see an example
-written to conventions the page doesn't describe — a caption claiming "written
-using the conventions described below" over a changelog that isn't.
+That's exactly right for the newest version's page, but wrong for older ones.
+As reported in [issue #720's comments](https://github.com/olivierlacan/keep-a-changelog/issues/720#issuecomment-4831774411),
+the 1.0.0 and 1.1.0 pages were displaying the 2.0.0 example — a changelog
+whose preamble declares it follows a spec the page doesn't describe. The same
+would happen to `/en/2.0.0/` the day 2.1.0 or 3.0.0 ships.
 
 ## Approaches considered
 
@@ -38,12 +40,18 @@ is reconstructable from today's file.
 ## How derivation works
 
 `tools/changelog_pin.rb` (pure, unit-tested in `test/changelog_pin_test.rb`;
-wired up through the `changelog_preview`/`changelog_example_pinned?` helpers in
-`config.rb` and the hero figure in `source/layouts/layout.html.haml`):
+wired up through the `changelog_example`/`changelog_preview`/
+`changelog_example_pinned?` helpers in `config.rb`, the hero figure in
+`source/layouts/layout.html.haml`, and the `changelog_example` embed in every
+pre-2.0 version page):
 
-- A page shows a pinned view only when its spec version is **older than the
-  published `$last_version`**. The latest version's page — and any newer draft
-  being previewed — keeps showing the live file, `Unreleased` section and all.
+- A page shows a pinned view only when the changelog **already documents a
+  release on a newer major.minor track** than the page's. This is independent
+  of which version the site publishes as its default: the moment the 2.0.0
+  entry landed in `CHANGELOG.md`, the 1.x pages pinned to their own era, even
+  while 1.1.0 remained the published latest. The newest documented track's
+  page — and any still-undocumented draft — keeps showing the live file,
+  `Unreleased` section and all.
 - The pin cutoff is the **newest release on the page's major.minor track**
   (the 2.0.0 page pins to the last 2.0.x, not to 2.0.0 itself), because patch
   releases ship translations and site fixes without changing the spec.
@@ -62,8 +70,8 @@ wired up through the `changelog_preview`/`changelog_example_pinned?` helpers in
 
 - `CHANGELOG.md` stays the single source of truth, the same philosophy as the
   release tooling (`tools/changelog_release.rb`).
-- No release-time step: the moment `$last_version` moves past a version, that
-  version's page pins itself.
+- No release-time step: the moment the changelog records a release on a newer
+  track, the older tracks' pages pin themselves.
 - Later copy edits to old entries (typo fixes, clarified wording) still flow
   into the pinned views, and a patch release on an old track moves that track's
   pin forward automatically.

--- a/source/ar/1.0.0/index.html.haml
+++ b/source/ar/1.0.0/index.html.haml
@@ -22,7 +22,7 @@ p.yanked {direction:ltr;text-align:right}
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/cs/0.3.0/index.html.haml
+++ b/source/cs/0.3.0/index.html.haml
@@ -16,7 +16,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   Changelog je soubor, který obsahuje organizovaný, chronologicky seřazený
   seznam podstatných změn pro každou verzi daného projektu.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Co je smyslem changelogu?

--- a/source/cs/1.0.0/index.html.haml
+++ b/source/cs/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verze
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/cs/1.1.0/index.html.haml
+++ b/source/cs/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Verze
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/da/1.1.0/index.html.haml
+++ b/source/da/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/de/0.3.0/index.html.haml
+++ b/source/de/0.3.0/index.html.haml
@@ -16,7 +16,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   Liste aller erheblichen Änderungen enthält, die zwischen Veröffentlichungen (oder Versionen)
   des Projekts umgesetzt wurden.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Was ist der Zweck eines Changelogs?

--- a/source/de/1.0.0/index.html.haml
+++ b/source/de/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/de/1.1.0/index.html.haml
+++ b/source/de/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/en/0.3.0/index.html.haml
+++ b/source/en/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   A change log is a file which contains a curated, chronologically ordered
   list of notable changes for each version of a project.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### What’s the point of a change log?

--- a/source/en/1.0.0/index.html.haml
+++ b/source/en/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/en/1.1.0/index.html.haml
+++ b/source/en/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/es-ES/0.3.0/index.html.haml
+++ b/source/es-ES/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
 
   Un registro de cambios o “change log” de ahora en adelante, es un archivo que contiene una lista en orden cronológico sobre los cambios que vamos haciendo en cada reléase (o versión) de nuestro proyecto.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Cuál es el propósito del change log?

--- a/source/es-ES/1.0.0/index.html.haml
+++ b/source/es-ES/1.0.0/index.html.haml
@@ -14,7 +14,7 @@ version: 1.0.0
     Versión
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/es-ES/1.1.0/index.html.haml
+++ b/source/es-ES/1.1.0/index.html.haml
@@ -14,7 +14,7 @@ version: 1.1.0
     Versión
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/fa/1.0.0/index.html.haml
+++ b/source/fa/1.0.0/index.html.haml
@@ -21,7 +21,7 @@ pre {direction:ltr;text-align:left}
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/fa/1.1.0/index.html.haml
+++ b/source/fa/1.1.0/index.html.haml
@@ -21,7 +21,7 @@ pre {direction:ltr;text-align:left}
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/fr/0.3.0/index.html.haml
+++ b/source/fr/0.3.0/index.html.haml
@@ -16,7 +16,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   une liste triée chronologiquement des changements notables pour chaque
   version d’un projet
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Quel est l’intérêt d’un change log ?

--- a/source/fr/1.0.0/index.html.haml
+++ b/source/fr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/fr/1.1.0/index.html.haml
+++ b/source/fr/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/hr/1.0.0/index.html.haml
+++ b/source/hr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzija
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/id-ID/1.0.0/index.html.haml
+++ b/source/id-ID/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versi
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/id/1.1.0/index.html.haml
+++ b/source/id/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/it-IT/0.3.0/index.html.haml
+++ b/source/it-IT/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   Un change log è un file che contiene una lista curata e ordinata cronologicamente
   delle modifiche degne di nota per ogni versione di un progetto.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### A cosa serve un change log?

--- a/source/it-IT/1.0.0/index.html.haml
+++ b/source/it-IT/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versione
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/it-IT/1.1.0/index.html.haml
+++ b/source/it-IT/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versione
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ja/1.0.0/index.html.haml
+++ b/source/ja/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ja/1.1.0/index.html.haml
+++ b/source/ja/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ka/1.0.0/index.html.haml
+++ b/source/ka/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ko/1.0.0/index.html.haml
+++ b/source/ko/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ko/1.1.0/index.html.haml
+++ b/source/ko/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/layouts/layout.html.haml
+++ b/source/layouts/layout.html.haml
@@ -126,11 +126,18 @@
               %h1= current_page.data.title
             %p.tagline= current_page.data.description
             %figure.changelog-figure
+              -# Pages for spec versions older than the published latest show the
+              -# changelog pinned to their track's last release, so the example
+              -# always follows the conventions this page describes.
+              - pinned_example = changelog_example_pinned?(current_version)
               %figcaption.changelog-caption
-                This is our own changelog, written using the conventions described below.
+                - if pinned_example
+                  = "This is our own changelog as of the last #{current_version.split(".").first(2).join(".")} release, written using the conventions described below."
+                - else
+                  This is our own changelog, written using the conventions described below.
               %details.changelog-example
                 %summary Example changelog
-                %pre.changelog{ lang: current_page.data.language, tabindex: "0", role: "region", "aria-label": "Keep a Changelog's own changelog" }= changelog_preview
+                %pre.changelog{ lang: current_page.data.language, tabindex: "0", role: "region", "aria-label": "Keep a Changelog's own changelog" }= changelog_preview(current_version)
           .article-body
             %p.version-marker
               = link_to data.links.changelog do

--- a/source/nb/1.1.0/index.html.haml
+++ b/source/nb/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versjon
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/nl/1.0.0/index.html.haml
+++ b/source/nl/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Versie
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/nl/1.1.0/index.html.haml
+++ b/source/nl/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versie
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/pl/0.3.0/index.html.haml
+++ b/source/pl/0.3.0/index.html.haml
@@ -14,7 +14,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   ### Czym jest changelog?
   Changelog, inaczej rejestr zmian lub historia zmian, to plik zawierający chronologicznie uporządkowaną listę istotnych zmian dla każdej wersji projektu.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Co jest celem prowadzenia changelogu?

--- a/source/pl/1.0.0/index.html.haml
+++ b/source/pl/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Wersja
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/pl/1.1.0/index.html.haml
+++ b/source/pl/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Wersja
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/pt-BR/0.3.0/index.html.haml
+++ b/source/pt-BR/0.3.0/index.html.haml
@@ -17,7 +17,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   cronologicamente, de mudanças significativas para cada versão de um projeto
   *open source*.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Para que serve um *changelog*?

--- a/source/pt-BR/1.0.0/index.html.haml
+++ b/source/pt-BR/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/pt-BR/1.1.0/index.html.haml
+++ b/source/pt-BR/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ro/1.1.0/index.html.haml
+++ b/source/ro/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Versiune
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ru/0.3.0/index.html.haml
+++ b/source/ru/0.3.0/index.html.haml
@@ -17,7 +17,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   хронологическом порядке список значимых изменений для каждой версии проекта с
   открытым исходным кодом.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Для чего нужен лог изменений?

--- a/source/ru/1.0.0/index.html.haml
+++ b/source/ru/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/ru/1.1.0/index.html.haml
+++ b/source/ru/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sk/1.0.0/index.html.haml
+++ b/source/sk/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzia
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sl/0.3.0/index.html.haml
+++ b/source/sl/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   Dnevnik sprememb je datoteka, ki vsebuje kuriran, kronološko urejen
   seznam opaznih sprememb za vsako verzijo projekta.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Kaj je smisel dnevnika sprememb?

--- a/source/sl/1.0.0/index.html.haml
+++ b/source/sl/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Različica
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sl/1.1.0/index.html.haml
+++ b/source/sl/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Različica
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sr/1.0.0/index.html.haml
+++ b/source/sr/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Verzija
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sv/0.3.0/index.html.haml
+++ b/source/sv/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   En ändringslogg är en fil innehållandes en sammanfattad, kronologiskt ordnad
   lista över ändringar för varje version av ett projekt.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Vad är meningen med en ändringslogg?

--- a/source/sv/1.0.0/index.html.haml
+++ b/source/sv/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/sv/1.1.0/index.html.haml
+++ b/source/sv/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/tr-TR/0.3.0/index.html.haml
+++ b/source/tr-TR/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   Değişiklik kayıtları bir proje için özel olarak hazırlanmış, tarihsel sıralamayla
   sıralanmış, önemli değişikliklerin bir bütünüdür.
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### Değişikliklerin kayıtlarını tutmanın anlamı ne?

--- a/source/tr-TR/1.0.0/index.html.haml
+++ b/source/tr-TR/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/tr-TR/1.1.0/index.html.haml
+++ b/source/tr-TR/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/uk/1.0.0/index.html.haml
+++ b/source/uk/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/uk/1.1.0/index.html.haml
+++ b/source/uk/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/zh-CN/0.3.0/index.html.haml
+++ b/source/zh-CN/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   更新日志（Change Log）是一个由人工编辑，以时间为倒序的列表。
   这个列表记录所有版本的重大变动。
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### 为何要提供更新日志？

--- a/source/zh-CN/1.0.0/index.html.haml
+++ b/source/zh-CN/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/zh-CN/1.1.0/index.html.haml
+++ b/source/zh-CN/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/zh-TW/0.3.0/index.html.haml
+++ b/source/zh-TW/0.3.0/index.html.haml
@@ -15,7 +15,7 @@ Version <strong>#{current_page.metadata[:page][:version]}</strong>
   更新日誌（Change Log）是一個由人工編輯，以時間為倒敘的列表。
   這個列表記錄所有版本的重大變動。
 
-<pre class="changelog">#{File.read("CHANGELOG.md")}</pre>
+<pre class="changelog">#{changelog_example}</pre>
 
 :markdown
   ### 為何要提供更新日誌？

--- a/source/zh-TW/1.0.0/index.html.haml
+++ b/source/zh-TW/1.0.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.0.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/source/zh-TW/1.1.0/index.html.haml
+++ b/source/zh-TW/1.1.0/index.html.haml
@@ -13,7 +13,7 @@ version: 1.1.0
     Version
     %strong= current_page.metadata[:page][:version]
 
-  %pre.changelog{ lang: "en" }= File.read("CHANGELOG.md")
+  %pre.changelog{ lang: "en" }= changelog_example
 
 .answers
   %h3#what

--- a/test/changelog_pin_test.rb
+++ b/test/changelog_pin_test.rb
@@ -1,0 +1,176 @@
+require "minitest/autorun"
+require_relative "../tools/changelog_pin"
+
+# The version-pinned hero example: a spec page older than the published latest
+# shows the project changelog as it stood at that track's last release, derived
+# from the one live CHANGELOG.md. These tests pin the derivation rules against a
+# fixture written from a hypothetical future (a 3.0.0 spec has shipped), then
+# check the invariants that hold against the real CHANGELOG.md today.
+class ChangelogPinPinnedTest < Minitest::Test
+  def test_older_versions_are_pinned
+    assert ChangelogPin.pinned?("2.0.0", last_version: "2.1.0")
+    assert ChangelogPin.pinned?("1.1.0", last_version: "2.0.0")
+  end
+
+  def test_the_latest_version_shows_the_live_changelog
+    refute ChangelogPin.pinned?("2.0.0", last_version: "2.0.0")
+  end
+
+  def test_a_newer_draft_shows_the_live_changelog
+    # Production today: $last_version is 1.1.0 while the 2.0.0 draft is built
+    # and previewable. The draft's page must keep showing the live changelog.
+    refute ChangelogPin.pinned?("2.0.0", last_version: "1.1.0")
+  end
+end
+
+class ChangelogPinTrackReleaseTest < Minitest::Test
+  FIXTURE = <<~MD
+    ## [Unreleased]
+    ## [3.0.0] - 2027-01-01
+    ## [2.0.10] - 2026-12-01
+    ## [2.0.2] - 2026-08-01
+    ## [2.0.0] - 2026-06-07
+    ## [1.1.2] - 2024-09-27
+  MD
+
+  def test_pins_to_the_last_patch_of_the_track_not_the_minor_itself
+    # 2.0.10 vs 2.0.2 also proves numeric (not lexical) version comparison.
+    assert_equal "2.0.10", ChangelogPin.track_release(FIXTURE, "2.0.0")
+  end
+
+  def test_each_track_finds_its_own_newest_release
+    assert_equal "3.0.0", ChangelogPin.track_release(FIXTURE, "3.0.0")
+    assert_equal "1.1.2", ChangelogPin.track_release(FIXTURE, "1.1.0")
+  end
+
+  def test_a_track_with_no_recorded_release_returns_nil
+    assert_nil ChangelogPin.track_release(FIXTURE, "1.0.0")
+  end
+end
+
+class ChangelogPinPinTest < Minitest::Test
+  # A future changelog: 3.0.0 has shipped, work is brewing in Unreleased, and
+  # the 2.0.x track ended at 2.0.1. Pinning for the 2.0.0 page must reconstruct
+  # the changelog as it stood at 2.0.1.
+  FIXTURE = <<~MD
+    # Changelog
+
+    All notable changes to this project will be documented in this file.
+
+    The format is based on [Keep a Changelog](https://keepachangelog.com/en/3.0.0/),
+    and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+    ## [Unreleased]
+
+    ### Added
+
+    - Something brewing for the next release.
+
+    ## [3.0.0] - 2027-01-01
+
+    ### Changed
+
+    - **Breaking:** everything, per the new conventions.
+
+    ## [2.0.1] - 2026-08-01
+
+    ### Fixed
+
+    - Improve French translation.
+
+    ## [2.0.0] - 2026-06-07
+
+    ### Added
+
+    - New guidance, contributed by [@someone].
+
+    ## [1.1.2] - 2024-09-27
+
+    ### Added
+
+    - v1.1 German translation.
+
+    [unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v3.0.0...HEAD
+    [3.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.1...v3.0.0
+    [2.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...v2.0.1
+    [2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.2...v2.0.0
+    [1.1.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...v1.1.2
+    [@someone]: https://github.com/someone
+  MD
+
+  def pinned
+    @pinned ||= ChangelogPin.pin(FIXTURE, "2.0.0")
+  end
+
+  def test_entries_newer_than_the_track_are_dropped
+    refute_includes pinned, "[3.0.0] - 2027-01-01"
+    refute_includes pinned, "**Breaking:** everything"
+  end
+
+  def test_the_track_and_everything_older_survive_intact
+    assert_includes pinned, "## [2.0.1] - 2026-08-01"
+    assert_includes pinned, "- Improve French translation."
+    assert_includes pinned, "## [2.0.0] - 2026-06-07"
+    assert_includes pinned, "## [1.1.2] - 2024-09-27"
+    assert_includes pinned, "- v1.1 German translation."
+  end
+
+  def test_unreleased_keeps_its_heading_but_loses_its_contents
+    # The Unreleased section is part of the format being taught, so the heading
+    # stays; its entries describe work newer than the pinned track, so they go.
+    assert_includes pinned, "## [Unreleased]"
+    refute_includes pinned, "Something brewing"
+  end
+
+  def test_the_unreleased_compare_link_diffs_from_the_tracks_last_release
+    assert_includes pinned, "[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.1...HEAD"
+  end
+
+  def test_dropped_entries_lose_their_link_definitions
+    refute_includes pinned, "[3.0.0]:"
+    assert_includes pinned, "[2.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...v2.0.1"
+  end
+
+  def test_non_version_link_definitions_are_kept
+    assert_includes pinned, "[@someone]: https://github.com/someone"
+    assert_includes pinned, "[Semantic Versioning](https://semver.org/spec/v2.0.0.html)"
+  end
+
+  def test_the_preamble_points_at_the_pinned_spec_version
+    assert_includes pinned, "https://keepachangelog.com/en/2.0.0/"
+    refute_includes pinned, "https://keepachangelog.com/en/3.0.0/"
+  end
+
+  def test_no_release_on_the_track_returns_the_text_unchanged
+    assert_equal FIXTURE, ChangelogPin.pin(FIXTURE, "1.0.0")
+  end
+
+  def test_the_emptied_unreleased_section_stays_well_formed
+    assert_includes pinned, "## [Unreleased]\n\n## [2.0.1] - 2026-08-01"
+  end
+end
+
+class ChangelogPinRealChangelogTest < Minitest::Test
+  REAL = File.read(File.expand_path("../CHANGELOG.md", __dir__), encoding: "UTF-8")
+
+  def test_pinning_the_1_1_page_reconstructs_the_1_1_2_era
+    pinned = ChangelogPin.pin(REAL, "1.1.0")
+
+    refute_includes pinned, "## [2.0.0]"
+    refute_includes pinned, "[2.0.0]:"
+    assert_includes pinned, "## [1.1.2] - 2024-09-27"
+    assert_includes pinned, "compare/v1.1.2...HEAD"
+    assert_includes pinned, "https://keepachangelog.com/en/1.1.0/"
+  end
+
+  def test_pinning_the_latest_track_matches_the_live_changelog
+    # While 2.0.x is the newest track, its pinned view and the live file must
+    # agree (the live Unreleased section is empty between releases). This
+    # guards the derivation against mangling text it shouldn't touch — if an
+    # Unreleased entry is in flight, the only allowed difference is that the
+    # pinned view empties that section.
+    pinned = ChangelogPin.pin(REAL, "2.0.0")
+    live_with_unreleased_emptied = REAL.sub(/(## \[Unreleased\]\n\n).*?(?=## \[)/m, '\1')
+    assert_equal live_with_unreleased_emptied, pinned
+  end
+end

--- a/test/changelog_pin_test.rb
+++ b/test/changelog_pin_test.rb
@@ -7,19 +7,38 @@ require_relative "../tools/changelog_pin"
 # fixture written from a hypothetical future (a 3.0.0 spec has shipped), then
 # check the invariants that hold against the real CHANGELOG.md today.
 class ChangelogPinPinnedTest < Minitest::Test
-  def test_older_versions_are_pinned
-    assert ChangelogPin.pinned?("2.0.0", last_version: "2.1.0")
-    assert ChangelogPin.pinned?("1.1.0", last_version: "2.0.0")
+  # The newest release the changelog documents is 2.0.0.
+  FIXTURE = <<~MD
+    ## [Unreleased]
+    ## [2.0.0] - 2026-06-07
+    ## [1.1.2] - 2024-09-27
+    ## [1.1.0] - 2019-02-15
+  MD
+
+  def test_pages_on_older_tracks_are_pinned
+    # The 1.1.0 page pins as soon as the changelog records 2.0.0, regardless of
+    # which version the site publishes as its default (the issue #720 report:
+    # 1.x pages were showing the 2.0.0 example while 1.1.0 was still latest).
+    assert ChangelogPin.pinned?(FIXTURE, "1.1.0")
+    assert ChangelogPin.pinned?(FIXTURE, "1.0.0")
+    assert ChangelogPin.pinned?(FIXTURE, "0.3.0")
   end
 
-  def test_the_latest_version_shows_the_live_changelog
-    refute ChangelogPin.pinned?("2.0.0", last_version: "2.0.0")
+  def test_the_newest_documented_track_shows_the_live_changelog
+    refute ChangelogPin.pinned?(FIXTURE, "2.0.0")
   end
 
-  def test_a_newer_draft_shows_the_live_changelog
-    # Production today: $last_version is 1.1.0 while the 2.0.0 draft is built
-    # and previewable. The draft's page must keep showing the live changelog.
-    refute ChangelogPin.pinned?("2.0.0", last_version: "1.1.0")
+  def test_patch_releases_stay_on_their_minor_track
+    # A 2.0.1 entry must not pin the 2.0.0 page — same track.
+    refute ChangelogPin.pinned?("## [2.0.1] - 2026-08-01\n", "2.0.0")
+  end
+
+  def test_a_draft_page_newer_than_every_entry_shows_the_live_changelog
+    refute ChangelogPin.pinned?(FIXTURE, "3.0.0")
+  end
+
+  def test_a_changelog_with_no_dated_entries_never_pins
+    refute ChangelogPin.pinned?("# Changelog\n", "1.0.0")
   end
 end
 
@@ -152,6 +171,13 @@ end
 
 class ChangelogPinRealChangelogTest < Minitest::Test
   REAL = File.read(File.expand_path("../CHANGELOG.md", __dir__), encoding: "UTF-8")
+
+  def test_the_1_1_page_pins_today
+    # The live changelog documents 2.0.0, so every 1.x and 0.x page is pinned
+    # right now — this is the fix for the issue #720 report.
+    assert ChangelogPin.pinned?(REAL, "1.1.0")
+    refute ChangelogPin.pinned?(REAL, "2.0.0")
+  end
 
   def test_pinning_the_1_1_page_reconstructs_the_1_1_2_era
     pinned = ChangelogPin.pin(REAL, "1.1.0")

--- a/tools/changelog_pin.rb
+++ b/tools/changelog_pin.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rubygems" # Gem::Version
+
+# Derives a version-pinned view of the project's own CHANGELOG.md — the hero
+# "Example changelog" shown on each spec page — so the example always follows
+# the conventions of the spec version being read.
+#
+# The live CHANGELOG.md tracks the *latest* spec. Once a newer spec ships, an
+# older version's page (say /en/2.0.0/ after 2.1.0 is released) should show the
+# changelog as it stood at that track's last release, not one written to newer
+# conventions. Rather than snapshotting files or maintaining per-minor tracking
+# branches (the production deploy builds from a single shallow checkout, so
+# other branches and tags aren't even available at build time), the pinned view
+# is derived from the one live CHANGELOG.md at render time:
+#
+#   - entries newer than the page's major.minor track are dropped, along with
+#     their version link definitions
+#   - the Unreleased section keeps its heading (it's part of the format being
+#     taught) but is emptied — its contents describe work newer than the track
+#   - the [unreleased] compare link is rewritten to diff from the track's last
+#     release, and the "based on Keep a Changelog" spec URL in the preamble is
+#     rewritten to the page's version
+#
+# CHANGELOG.md stays the single source of truth (the same philosophy as
+# tools/changelog_release.rb), there is no release-checklist step to forget,
+# and later copy edits to old entries still reach the pinned views.
+#
+# Pure and framework-free so it can be unit-tested without booting Middleman.
+# See test/changelog_pin_test.rb.
+module ChangelogPin
+  module_function
+
+  # A version heading, dated or not, e.g. "## [1.1.0] - 2019-02-15".
+  VERSION_HEADING = /^\#\#\s*\[(\d+\.\d+\.\d+)\]/
+  UNRELEASED_HEADING = /^\#\#\s*\[unreleased\]/i
+
+  # Reference-link definitions at the bottom of the file.
+  VERSION_LINK_DEF = /^\[(\d+\.\d+\.\d+)\]:\s/
+  UNRELEASED_LINK_DEF = /^\[unreleased\]:\s/i
+  LINK_DEF = /^\[[^\]]+\]:\s/
+
+  # Should +page_version+'s page show a pinned view instead of the live
+  # changelog? Only pages older than the published latest: the latest version's
+  # page (and any newer draft being previewed) shows the live file, Unreleased
+  # section and all.
+  def pinned?(page_version, last_version:)
+    Gem::Version.new(page_version) < Gem::Version.new(last_version)
+  end
+
+  # The newest release recorded in +text+ on the page's major.minor track —
+  # patch releases ship translations and site fixes without changing the spec,
+  # so the 2.0.0 page pins to the last 2.0.x, not to 2.0.0 itself. Returns nil
+  # if the changelog has no entry on that track.
+  def track_release(text, page_version)
+    major, minor, = page_version.split(".")
+    prefix = "#{major}.#{minor}."
+    text.scan(VERSION_HEADING).flatten
+      .select { |version| version.start_with?(prefix) }
+      .max_by { |version| Gem::Version.new(version) }
+  end
+
+  # The changelog as it stood at the last release on +page_version+'s track.
+  # Returns +text+ unchanged when the track has no recorded release to pin to.
+  def pin(text, page_version)
+    cutoff_string = track_release(text, page_version)
+    return text unless cutoff_string
+
+    cutoff = Gem::Version.new(cutoff_string)
+    out = []
+    dropping = false
+
+    text.each_line do |raw|
+      line = raw.chomp
+
+      # The link-definition block ends the sections, so it is handled first —
+      # these lines are kept or dropped on their own terms, never as part of a
+      # dropped section body.
+      if (match = line.match(VERSION_LINK_DEF))
+        out << line unless Gem::Version.new(match[1]) > cutoff
+        next
+      end
+      if line.match?(UNRELEASED_LINK_DEF)
+        out << line.sub(%r{compare/v\d+\.\d+\.\d+\.\.\.HEAD}, "compare/v#{cutoff_string}...HEAD")
+        next
+      end
+      if line.match?(LINK_DEF)
+        out << line
+        next
+      end
+
+      if line.match?(UNRELEASED_HEADING)
+        out << line << ""
+        dropping = true # empty the section; the blank line above stands in for its body
+        next
+      end
+      if (match = line.match(VERSION_HEADING))
+        dropping = Gem::Version.new(match[1]) > cutoff
+        out << line unless dropping
+        next
+      end
+
+      out << line unless dropping
+    end
+
+    out.join("\n")
+      .sub(%r{(keepachangelog\.com/en/)\d+\.\d+\.\d+/}, "\\1#{page_version}/")
+      .then { |result| result.end_with?("\n") ? result : "#{result}\n" }
+  end
+end

--- a/tools/changelog_pin.rb
+++ b/tools/changelog_pin.rb
@@ -6,8 +6,9 @@ require "rubygems" # Gem::Version
 # "Example changelog" shown on each spec page — so the example always follows
 # the conventions of the spec version being read.
 #
-# The live CHANGELOG.md tracks the *latest* spec. Once a newer spec ships, an
-# older version's page (say /en/2.0.0/ after 2.1.0 is released) should show the
+# The live CHANGELOG.md tracks the *newest* spec it documents. A page for an
+# older spec (say /en/1.1.0/ once the changelog records 2.0.0, or /en/2.0.0/
+# after 2.1.0 is released — see the report in issue #720) should show the
 # changelog as it stood at that track's last release, not one written to newer
 # conventions. Rather than snapshotting files or maintaining per-minor tracking
 # branches (the production deploy builds from a single shallow checkout, so
@@ -41,11 +42,21 @@ module ChangelogPin
   LINK_DEF = /^\[[^\]]+\]:\s/
 
   # Should +page_version+'s page show a pinned view instead of the live
-  # changelog? Only pages older than the published latest: the latest version's
-  # page (and any newer draft being previewed) shows the live file, Unreleased
+  # changelog? Only when the changelog already documents a release on a newer
+  # major.minor track than the page's — the moment a 2.0.0 entry lands, the
+  # 1.1.0 page pins to the 1.1.x era, regardless of which version the site
+  # currently publishes as its default. The page for the newest documented
+  # track (and any still-undocumented draft) shows the live file, Unreleased
   # section and all.
-  def pinned?(page_version, last_version:)
-    Gem::Version.new(page_version) < Gem::Version.new(last_version)
+  def pinned?(text, page_version)
+    newest = text.scan(VERSION_HEADING).flatten.max_by { |v| Gem::Version.new(v) }
+    return false unless newest
+    track(newest) > track(page_version)
+  end
+
+  # A version's major.minor track, as a comparable Gem::Version.
+  def track(version)
+    Gem::Version.new(version.split(".").first(2).join("."))
   end
 
   # The newest release recorded in +text+ on the page's major.minor track —


### PR DESCRIPTION
Addresses [@jaller94's report in #720](https://github.com/olivierlacan/keep-a-changelog/issues/720#issuecomment-4831774411) that the 1.0.0 and 1.1.0 pages display the 2.0.0 example changelog (without closing that issue, whose headline question is about the default link).

Every spec page embeds the project's own CHANGELOG.md as its example — the 2.0+ hero figure and the pre-2.0 header `<pre>` alike. The live file follows the newest spec it documents, so older pages were showing an example written to conventions they don't describe (and pointing at the wrong spec URL in its preamble).

Instead of per-minor tracking branches or committed snapshots (the deploy builds from a single shallow checkout, and both add upkeep that drifts), the pinned view is **derived from the one live CHANGELOG.md at build time**. A page pins as soon as the changelog documents a release on a newer major.minor track than the page's — independent of which version the site publishes as its default, which is why the 1.x pages pin today even though 1.1.0 is still the published latest. The derivation:

- drops entries newer than the page's track (cutoff is the track's last **patch**, so translation-batch patches like 1.1.2 stay with 1.1.0) along with their link definitions
- keeps the `Unreleased` heading (it's part of the format being taught) but empties its contents
- rewrites the `[unreleased]` compare link to diff from the track's last release, and the preamble's "based on Keep a Changelog" URL to the page's spec version
- captions the 2.0+ hero "as of the last x.y release" when pinned

The newest documented track's page (2.0.0 today) keeps showing the live file, `Unreleased` section and all. All 63 pre-2.0 version pages (every language) now embed the pinned view via a `changelog_example` helper; the derivation lives in a pure, unit-tested module (`tools/changelog_pin.rb`), following the `version_routing` pattern. `docs/version-pinned-example.md` records the design and the approaches considered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfKsJk5bCVd5AizBW8gZf2