### PR TITLE
Fix translation contribute links to point to CONTRIBUTING.md

### DIFF
--- a/source/translations/index.html.erb
+++ b/source/translations/index.html.erb
@@ -155,7 +155,7 @@ title: Available translations — Keep a Changelog
     Keep a Changelog is written in <a href="/en/<%= published %>/">English</a>
     and translated by volunteers into <%= entries.size %> languages.
     <%= current.size %> translations cover the current version (<%= published %>).
-    Want to help? <a href="https://github.com/olivierlacan/keep-a-changelog#translations">Contribute a translation</a>,
+    Want to help? <a href="https://github.com/olivierlacan/keep-a-changelog/blob/main/CONTRIBUTING.md#translations">Contribute a translation</a>,
     or dig into the <a href="/translations/progress/">detailed progress dashboard</a>.
   </p>
 
@@ -174,7 +174,7 @@ title: Available translations — Keep a Changelog
   <h2>Older version available (<%= outdated.size %>)</h2>
   <p class="group-desc">
     These translations exist but haven't caught up with <%= published %> yet —
-    a great place to <a href="https://github.com/olivierlacan/keep-a-changelog#translations">lend a hand</a>.
+    a great place to <a href="https://github.com/olivierlacan/keep-a-changelog/blob/main/CONTRIBUTING.md#translations">lend a hand</a>.
   </p>
   <div class="grid">
     <% outdated.each do |e| %>


### PR DESCRIPTION
## What

Both the "Contribute a translation" and "lend a hand" links on the translations overview page pointed to `https://github.com/olivierlacan/keep-a-changelog#translations` — a `#translations` anchor on the repo README. The README has no Translations heading, so both links landed at the top of the README instead of the contribution guidance.

They now point to the **Translations** section of `CONTRIBUTING.md`, where the translation how-to actually lives:

`https://github.com/olivierlacan/keep-a-changelog/blob/main/CONTRIBUTING.md#translations`

## Why

A reader who clicks "Want to help? Contribute a translation" should land on the instructions for doing exactly that. The old anchor silently sent them nowhere useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)