### PR TITLE
Fix production 404s behind the version and language selectors

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -201,28 +201,33 @@ end
 # selectors offer *every* version for *every* language (issue #719): pick one we
 # don't have and you land somewhere helpful rather than nowhere.
 #
-# We mirror the selector's exposure rule: all spec versions when serving locally
-# (so an in-progress 2.0.0 draft previews), capped at the published $last_version
-# in a production build so unreleased drafts never ship.
+# Interstitials cover every version with an English page — including an
+# unreleased draft like 2.0.0. The draft page itself ships in production
+# (that's how it is previewed), and its language selector links every language
+# at that version, so each of those URLs must resolve. Capping this at
+# $last_version in production builds made /fr/2.0.0/ a 404 that the dev
+# server, which generated the full set, never showed. Keeping drafts from
+# being *surfaced* is the job of selectable_versions, which caps the version
+# dropdown in production builds; it is not a reason to leave selector-emitted
+# URLs dangling.
 spec_versions = $versions.select { |v| File.directory?("source/en/#{v}") }
 
-generate_interstitials = lambda do |max_version|
-  $languages.each_key do |code|
-    spec_versions.each do |version|
-      next if max_version && Gem::Version.new(version) > Gem::Version.new(max_version)
-      next if File.directory?("source/#{code}/#{version}") # real translation exists
-      proxy "/#{code}/#{version}/index.html", "/missing.html",
-        locals: { language_code: code, version: version }, ignore: true
-    end
+# Beyond the registered $languages, cover any stray language directory in
+# source/ (e.g. "id", the unregistered duplicate of "id-ID"): its pages build
+# and render the version selector like any other, so their untranslated
+# versions need interstitials too — /id/1.0.0/ was a production 404 reachable
+# from /id/1.1.0/'s own version dropdown.
+language_dirs = Dir.glob("source/*/*/")
+  .select { |d| File.basename(d) =~ /\A\d+\.\d+\.\d+\z/ }
+  .map { |d| File.basename(File.dirname(d)) }
+  .uniq
+
+($languages.keys | language_dirs).each do |code|
+  spec_versions.each do |version|
+    next if File.directory?("source/#{code}/#{version}") # real translation exists
+    proxy "/#{code}/#{version}/index.html", "/missing.html",
+      locals: { language_code: code, version: version }, ignore: true
   end
-end
-
-configure :development do
-  generate_interstitials.call(nil)
-end
-
-configure :build do
-  generate_interstitials.call($last_version)
 end
 
 # Patch releases of this project (e.g. 1.1.1) ship fixes to the site and tooling

--- a/test/build_test.rb
+++ b/test/build_test.rb
@@ -1,11 +1,37 @@
 require "minitest/autorun"
 
-class TestMeme < Minitest::Test
-  def setup
-    @output = `bin/rake build`
+class BuildTest < Minitest::Test
+  # Building is expensive, so it happens once for the whole class rather than
+  # in a per-test setup.
+  def self.output
+    @output ||= `bin/rake build`
   end
 
-  def test_build
-    assert @output.include?("Project built successfully.") 
+  def test_build_succeeds
+    assert_includes BuildTest.output, "Project built successfully."
+  end
+
+  # Every URL the version + language selectors emit must resolve within the
+  # build. The dropdowns deliberately offer combinations with no real
+  # translation (those land on a generated interstitial), and the dev server
+  # papers over any gap by generating more pages than a production build —
+  # which is exactly how /fr/2.0.0/ shipped as a 404: the language switcher on
+  # the shipped English 2.0.0 draft linked 27 pages the build didn't contain,
+  # and dev, generating interstitials for every version, never showed it.
+  # Scanning the shipped HTML for the selectors' actual targets pins the
+  # invariant without duplicating the exposure rules that decide them.
+  def test_every_selector_option_resolves_in_the_build
+    BuildTest.output
+    pages = Dir.glob("build/**/index.html")
+    refute_empty pages, "no built pages found — did the build run?"
+
+    targets = pages.flat_map do |page|
+      File.read(page).scan(/<option[^>]*\bvalue=['"]([^'"]+)['"]/).flatten
+    end.uniq
+    refute_empty targets, "no selector options found in the built pages"
+
+    missing = targets.reject { |target| File.exist?("build/#{target}index.html") }
+    assert_empty missing.map { |target| "/#{target}" },
+      "selector options whose target page is not in the build"
   end
 end


### PR DESCRIPTION
Switching to French while viewing the shipped English 2.0.0 draft led to a production 404 at `/fr/2.0.0/` (reported after #729 merged), while the same click worked in dev.

The interstitial generation in `config.rb` was split by environment: dev generated the full set, production builds capped it at the published `$last_version`. But the English 2.0.0 draft page ships in production regardless (that's how it is previewed), and its language selector links every language at the current page's version — 27 URLs the production build never contained. The cap protected nothing, and dev, generating more pages than production, structurally could not show the gap. Interstitials are now generated identically in every environment, for every version that has an English page; keeping drafts out of the version dropdown remains the job of `selectable_versions`, which is unchanged.

The new build test also surfaced two pre-existing production 404s unrelated to 2.0.0: the stray unregistered `id` directory (duplicate of `id-ID`) builds real pages whose version dropdown links `/id/1.0.0/` and `/id/0.3.0/`, which never got interstitials because `id` isn't in `$languages`. Generation now also covers stray language directories in `source/`.

The regression test replaces the bare "build succeeds" check in `test/build_test.rb`: it scans every built page for the selectors' actual `<option value>` targets and requires each to resolve within the build, so it pins the invariant — every URL the selectors emit ships — without duplicating the exposure rules that decide them. Verified both ways: against the old config it fails listing all 29 dangling URLs; with the fix the full suite passes (79 runs, 0 failures). `/fr/2.0.0/` now builds as the proper French interstitial.

Production needs a deploy after this merges to pick up the generated pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKyptz9fXTJ1Di4xZ9ZGFz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKyptz9fXTJ1Di4xZ9ZGFz)_