### PR TITLE
Add guidance on avoiding changelog merge conflicts

### DIFF
--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -208,13 +208,9 @@ A single file is usually fine, even a long one; many projects keep decades of hi
 
 ### How do I avoid changelog merge conflicts? {#merge-conflicts}
 
-A shared `Unreleased` section is easy to keep, but it has one rough edge: when several branches add entries in the same place, they conflict when you merge them. For most projects this is rare and quick to fix by hand. Two habits make it rarer: keep each entry short, and add it in the same branch that makes the change, so the entry travels with the work.
+A shared `Unreleased` section is convenient, but it may lead to merge conflicts when branches are frequently merged. While keeping entries short and on the same branch as changes can help, when conflicts are frequent you can tell your version control system to retain conflicting lines with a union merge (e.g. `merge=union` in `.gitattributes` file).
 
-When conflicts get tedious, you can tell version control to keep both sides instead of stopping. In git, set a union merge for the changelog file (a `merge=union` line in a `.gitattributes` file), and two branches that each append an entry both survive the merge. This handles the common case — new lines added in the same spot — with no extra process.
-
-Higher-volume projects sometimes go further and keep each unreleased entry in its own file, in a directory such as `changelog.d/`. A branch adds a file instead of editing a shared section, so two branches never touch the same lines and cannot conflict. At release time the files are collected into a dated version in `CHANGELOG.md` and removed, usually by a small tool. Treat this as a scaling choice, not a default: it solves a real problem for projects with many parallel contributions, and adds friction to projects without them. Start with a shared `Unreleased` section and short entries, add a union merge if conflicts get tedious, and move to per-change files only when the volume clearly calls for it.
-
-Whichever you choose, remember that merging a branch is not the same as releasing. Several changes can land under `Unreleased` before anyone prepares a version, and what gathers there is not always one release: a maintainer may split it into several, or hold it, depending on what the changes are. Keep the entries under `Unreleased` as they merge, and decide the version boundaries later, when you cut the release.
+Higher-volume projects can also keep unreleased entries in a separate file inside a directory such as `changelog.d/`. Branches avoid conflict by not editing the same section of the changelog file. At release time the files can be combined into the `CHANGELOG.md` and removed from the subdirectory. This helps with scalability but it does adds complexity. It's best to start with a shared `Unreleased` section; add a union merge if conflicts become tedious; and evolve to per-branch files when it becomes unavoidable.
 
 ### What about monorepos? {#monorepos}
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -206,6 +206,16 @@ You can improve a changelog after a release. A project may forget an entry, or d
 
 A single file is usually fine, even a long one; many projects keep decades of history in one `CHANGELOG.md`. If it becomes hard to manage, you can move old history into separate files, but link the main file and the archives both ways, or readers will not find the older entries. Archive only versions old enough that they will not need editing, and do not delete old entries: someone may still upgrade from an old version.
 
+### How do I avoid changelog merge conflicts? {#merge-conflicts}
+
+A shared `Unreleased` section is easy to keep, but it has one rough edge: when several branches add entries in the same place, they conflict when you merge them. For most projects this is rare and quick to fix by hand. Two habits make it rarer: keep each entry short, and add it in the same branch that makes the change, so the entry travels with the work.
+
+When conflicts get tedious, you can tell version control to keep both sides instead of stopping. In git, set a union merge for the changelog file (a `merge=union` line in a `.gitattributes` file), and two branches that each append an entry both survive the merge. This handles the common case — new lines added in the same spot — with no extra process.
+
+Higher-volume projects sometimes go further and keep each unreleased entry in its own file, in a directory such as `changelog.d/`. A branch adds a file instead of editing a shared section, so two branches never touch the same lines and cannot conflict. At release time the files are collected into a dated version in `CHANGELOG.md` and removed, usually by a small tool. Treat this as a scaling choice, not a default: it solves a real problem for projects with many parallel contributions, and adds friction to projects without them. Start with a shared `Unreleased` section and short entries, add a union merge if conflicts get tedious, and move to per-change files only when the volume clearly calls for it.
+
+Whichever you choose, remember that merging a branch is not the same as releasing. Several changes can land under `Unreleased` before anyone prepares a version, and what gathers there is not always one release: a maintainer may split it into several, or hold it, depending on what the changes are. Keep the entries under `Unreleased` as they merge, and decide the version boundaries later, when you cut the release.
+
 ### What about monorepos? {#monorepos}
 
 It depends on whether the repository holds one product or many. Unrelated projects that share a repository each keep their own changelog. A single product made of many parts (say, a framework split into separate libraries) can keep a changelog per component, but should also keep one central changelog. Readers should not have to read a dozen component changelogs to understand what a release means. The per-component changelogs are the detailed record; the central one is the summary.


### PR DESCRIPTION
## What

Adds a new subsection, **"How do I avoid changelog merge conflicts?"**, under *Less common questions* in `source/en/2.0.0/index.html.md`. It addresses a recurring question from the [issues](https://github.com/olivierlacan/keep-a-changelog/issues) and [discussions](https://github.com/olivierlacan/keep-a-changelog/discussions): how to handle concurrent edits to the `Unreleased` section when several branches add entries at once.

## Why here

Placed in *Less common questions* rather than the main *Structuring a release* flow, so the simple default (one shared `Unreleased` section) stays clean and this reads as the advanced consideration it is — most projects never need it.

## What it says

Two paragraphs, walking up a ladder of effort so a reader adopts only as much as their volume requires:

1. **Keep it simple, then reach for a union merge.** Short entries added in the branch that makes the change keep conflicts rare. When they get frequent, tell version control to retain both sides with a union merge (`merge=union` in `.gitattributes`).
2. **`changelog.d/` for higher volume.** Keep each unreleased entry in its own file so branches never edit the same lines, then combine them into `CHANGELOG.md` at release time. Framed as a scaling choice that adds complexity: start with a shared `Unreleased` section, add a union merge if conflicts get tedious, and move to per-file entries only when unavoidable.

No specific tool is endorsed, consistent with the site's "no tool or service to install" stance.

## Related issues and discussions

This is the recurring request these threads asked for. They can be marked as addressed when this merges (all are already closed and locked):

**Issues**

- #56 — *merge=union*: asks the site to recommend `CHANGELOG.md merge=union`. Directly covered.
- #400 — *CHANGELOG.md | Git branches and merges*: requests a section on handling branches and merges.
- #301 — *No good way to handle changelogs for larger teams*: git conflicts on a shared changelog; proposes a per-change files directory (the `changelog.d/` idea).
- #230 — *Generate changelog based on Yaml files*: "I hate dealing with merge conflicts due to the `Unreleased` section"; per-file fragments.
- #244 — *Good process for keeping changelogs in a team*: team workflow, references GitLab's per-file approach.

**Discussions**

- [#502](https://github.com/olivierlacan/keep-a-changelog/discussions/502) — *How to version control the changelog?*: merge conflicts across PRs, plus a unique-id workaround for `Unreleased`.
- [#491](https://github.com/olivierlacan/keep-a-changelog/discussions/491) — *Generate changelog based on Yaml files* (discussion mirror of #230).
- [#501](https://github.com/olivierlacan/keep-a-changelog/discussions/501) — *Good process for keeping changelogs in a team* (discussion mirror of #244).

## Notes

- Content held to `docs/tone-and-voice.md`: leads with the point, plain words, short sentences, translator-friendly.
- Site builds successfully; the section renders with a `#merge-conflicts` anchor, which the JS-generated table of contents picks up automatically.
- English 2.0.0 only — translations are left to human translators per the project's workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)