### PR TITLE
2.0 guidance: area prefixes, change-type order, Security pointer, voice fixes + a prose lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+      - name: Lint prose
+        # Enforces docs/tone-and-voice.md on every English spec page. Dependency
+        # free, so it runs before the build and fails fast on a tone slip.
+        run: ruby tools/prose_lint.rb
+
       - name: Run tests
         run: bin/rake test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ are marked below.
 - New guidance answering long-standing community questions:
   - Format: the `# Changelog` header preamble; marking breaking changes and
     where upgrade steps belong; choosing between Changed, Fixed, and Security;
-    leading a Security entry with its CVE; why the six change types don't grow,
-    and a recommended order for them.
+    leading a Security entry with its CVE and pointing it to the full advisory;
+    why the six change types don't grow, and a recommended order for them.
   - Versioning: schemes beyond SemVer, and linking each version to a `compare`
     diff with reference links.
   - Changelogs vs. release notes: how to derive one from the other without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ are marked below.
 ### Added
 
 - New guidance answering long-standing community questions:
-  - Format: the `# Changelog` header preamble; marking breaking changes and
+  - Format: the `# Changelog` header preamble, and adopting a newer version of
+    the format without rewriting history; marking breaking changes and
     where upgrade steps belong; naming which part of the project an entry
     touches; choosing between Changed, Fixed, and Security; leading a Security
     entry with its CVE and pointing it to the full advisory; why the six change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ are marked below.
 - New guidance answering long-standing community questions:
   - Format: the `# Changelog` header preamble; marking breaking changes and
     where upgrade steps belong; choosing between Changed, Fixed, and Security;
-    leading a Security entry with its CVE; why the six change types don't grow.
+    leading a Security entry with its CVE; why the six change types don't grow,
+    and a recommended order for them.
   - Versioning: schemes beyond SemVer, and linking each version to a `compare`
     diff with reference links.
   - Changelogs vs. release notes: how to derive one from the other without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,10 @@ are marked below.
 
 - New guidance answering long-standing community questions:
   - Format: the `# Changelog` header preamble; marking breaking changes and
-    where upgrade steps belong; choosing between Changed, Fixed, and Security;
-    leading a Security entry with its CVE and pointing it to the full advisory;
-    why the six change types don't grow, and a recommended order for them.
+    where upgrade steps belong; naming which part of the project an entry
+    touches; choosing between Changed, Fixed, and Security; leading a Security
+    entry with its CVE and pointing it to the full advisory; why the six change
+    types don't grow, and a recommended order for them.
   - Versioning: schemes beyond SemVer, and linking each version to a `compare`
     diff with reference links.
   - Changelogs vs. release notes: how to derive one from the other without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,25 @@ section links no longer resolve, the recommended guidance has shifted, and
 existing translations are out of date until they catch up. The breaking changes
 are marked below.
 
+### Removed
+
+- Outdated specifics (the Vandamme gem reference and a GitHub-Releases
+  discoverability note) in favor of more general guidance.
+- **Breaking:** The FAQ scaffolding and most first-person framing, whose section
+  anchors no longer resolve; the podcast note now lives in the References section.
+
+### Changed
+
+- **Breaking:** Retired the tagline "Don't let your friends dump git logs into
+  changelogs" for "Clearly document the evolution of your projects." Earlier
+  versions keep the original.
+- **Breaking:** Restructured the page from a flat FAQ into integrated guidance,
+  in a plainer, less first-person voice. Some older section links no longer resolve.
+- Reframed the "GitHub Releases" answer as "Is a changelog the same as release
+  notes?", broadened beyond GitHub to any host.
+- Set page titles and descriptions from frontmatter, and fixed OpenGraph metadata
+  so shared links render correctly and language-appropriately.
+
 ### Added
 
 - New guidance answering long-standing community questions:
@@ -41,25 +60,6 @@ are marked below.
   - Optional per-release summaries, and a statement of what Keep a Changelog
     deliberately won't do.
 - A redesigned, accessible site (WCAG 2.1 AA) with light and dark themes.
-
-### Changed
-
-- **Breaking:** Retired the tagline "Don't let your friends dump git logs into
-  changelogs" for "Clearly document the evolution of your projects." Earlier
-  versions keep the original.
-- **Breaking:** Restructured the page from a flat FAQ into integrated guidance,
-  in a plainer, less first-person voice. Some older section links no longer resolve.
-- Reframed the "GitHub Releases" answer as "Is a changelog the same as release
-  notes?", broadened beyond GitHub to any host.
-- Set page titles and descriptions from frontmatter, and fixed OpenGraph metadata
-  so shared links render correctly and language-appropriately.
-
-### Removed
-
-- Outdated specifics (the Vandamme gem reference and a GitHub-Releases
-  discoverability note) in favor of more general guidance.
-- **Breaking:** The FAQ scaffolding and most first-person framing, whose section
-  anchors no longer resolve; the podcast note now lives in the References section.
 
 ## [1.1.2] - 2024-09-27
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,9 @@ and submit changes. For the principles behind how the project is built, see
 - `bin/rake build` runs middleman build with `--verbose` flag so build errors are
   logged for easier debugging
 - `bin/rake test` runs the Minitest suite (also the default task)
+- `bin/rake prose:lint` checks the English spec prose against
+  [docs/tone-and-voice.md](docs/tone-and-voice.md); it also runs in CI. Add
+  `<!-- prose-lint-ignore -->` to a line to skip a deliberate exception.
 - `bundle exec standardrb` checks Ruby style ([Standard][standard])
 
 ### Visual regression tests

--- a/Rakefile
+++ b/Rakefile
@@ -47,6 +47,13 @@ namespace :translations do
   end
 end
 
+namespace :prose do
+  desc "Lint the English spec prose against docs/tone-and-voice.md"
+  task :lint do
+    sh "ruby tools/prose_lint.rb"
+  end
+end
+
 namespace :snapshots do
   desc "Build, then record cross-browser baseline screenshots (run before migrating)"
   task baseline: :build do

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -80,7 +80,11 @@ plainer to translate. Older versions keep the original tagline.
   people ask about most — `Fixed` vs `Changed` vs `Security` — with a "was the old
   behavior a bug?" test, an **aside** on why there aren't more types (the reason
   for a change belongs in the entry's wording, not a new type), and direct answers
-  for **Dependencies** and **Known issues**. It also recommends a **section order
+  for **Dependencies** and **Known issues**. The **Security** guidance also frames
+  an entry as a pointer, not the advisory: keep it a short summary, link to the
+  advisory (CVE record, security database, or your own security page), and note
+  that formal disclosure duties (an advisory database, or rules for certain
+  products) are met elsewhere and pointed to, not replaced by the changelog. It also recommends a **section order
   by urgency** — `Security`, `Removed`, `Changed`, `Deprecated`, `Fixed`, `Added`,
   omitting empty sections — so what a reader must act on comes before what is
   optional, kept consistent across releases, with entry order within a section left

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -59,9 +59,9 @@ plainer to translate. Older versions keep the original tagline.
 
 ## At a glance
 
-- **9 new sections** of guidance: `#breaking`, `#curation`, `#automation`,
-  `#release-notes`, `#large-changelog`, `#monorepos`, `#linking`, `#scope`,
-  `#references`.
+- **10 new sections** of guidance: `#breaking`, `#areas`, `#curation`,
+  `#automation`, `#release-notes`, `#large-changelog`, `#monorepos`, `#linking`,
+  `#scope`, `#references`.
 - **Core advice restructured** from a flat FAQ into `#how` subsections.
 - **Several sections revised** in wording (mostly clarifications held back from
   minor releases — see the 2.0.0 changelog entry for why).
@@ -94,6 +94,13 @@ plainer to translate. Older versions keep the original tagline.
 - **`#breaking` — marking breaking changes (new).** A `**Breaking:**` marker on
   `Changed` / `Removed` entries rather than a new section, plus: name which
   interface your versioning scheme treats as stable.
+- **`#areas` — naming the part it touches (new).** An optional `Name:` lead-in
+  within a type (e.g. `- CLI: ...`) to say which part of the project an entry
+  changed, grouping entries by area on a second axis without a new `### CLI`
+  heading or a new change type. The sanctioned answer to the recurring
+  component/module/scope-category requests: the six types stay the set, and the
+  consistent prefix stays parseable. Pairs with the per-component changelog in
+  `#monorepos`.
 
 ### Versioning and release structure
 
@@ -267,7 +274,7 @@ the new and revised content rather than porting file formats.
   per-section breakdown.
 - Section ids are stable across languages, so a 2.0 translation should match the
   English id set: `#basics`, `#what`, `#why`, `#who`, `#how`, `#principles`, `#types`,
-  `#breaking`, `#releasing`, `#curation`, `#filename`, `#header`,
+  `#breaking`, `#areas`, `#releasing`, `#curation`, `#filename`, `#header`,
   `#release-notes`, `#bad-practices`, `#log-diffs`, `#ignoring-deprecations`,
   `#inconsistent-changes`, `#automation`, `#less-common`, `#yanked`, `#rewrite`,
   `#large-changelog`, `#monorepos`, `#linking`, `#credits`, `#about`, `#standard`,

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -89,7 +89,8 @@ plainer to translate. Older versions keep the original tagline.
   omitting empty sections — so what a reader must act on comes before what is
   optional, kept consistent across releases, with entry order within a section left
   to the author's judgment. This closes #458 (the highest-reaction open request)
-  and lands PR #706, which @olivierlacan slated for 2.0.
+  and lands the section-order recommendation from @abatko's PR #706, which
+  @olivierlacan slated for 2.0.
 - **`#breaking` — marking breaking changes (new).** A `**Breaking:**` marker on
   `Changed` / `Removed` entries rather than a new section, plus: name which
   interface your versioning scheme treats as stable.

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -80,7 +80,11 @@ plainer to translate. Older versions keep the original tagline.
   people ask about most — `Fixed` vs `Changed` vs `Security` — with a "was the old
   behavior a bug?" test, an **aside** on why there aren't more types (the reason
   for a change belongs in the entry's wording, not a new type), and direct answers
-  for **Dependencies** and **Known issues**.
+  for **Dependencies** and **Known issues**. It also recommends a **section order**
+  (the order the six types are listed, kept consistent across releases) and leaves
+  entry order within a section to the author's judgment — closing #458, the
+  highest-reaction open request, without mandating an order or contradicting the
+  examples.
 - **`#breaking` — marking breaking changes (new).** A `**Breaking:**` marker on
   `Changed` / `Removed` entries rather than a new section, plus: name which
   interface your versioning scheme treats as stable.

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -27,7 +27,8 @@ into a structured guide:
 - **`#how` — How do I keep a good changelog?** now holds the core guidance as
   named subsections instead of scattered Q&A: `#principles`, `#types`,
   `#breaking`, `#releasing`, `#curation`, plus the questions common enough to
-  count as core — `#filename`, `#header` (the `# Changelog` preamble), and
+  count as core — `#filename`, `#header` (the `# Changelog` preamble, and how to
+  adopt a newer version of the format without rewriting history), and
   `#release-notes`. Several of these absorbed adopter-driven conventions: CVE-first
   Security entries and the "keep to the six types" stance (`#types`), inline-vs-
   linked upgrade notes (`#breaking`), the `[version]` compare-link footer

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -80,11 +80,12 @@ plainer to translate. Older versions keep the original tagline.
   people ask about most — `Fixed` vs `Changed` vs `Security` — with a "was the old
   behavior a bug?" test, an **aside** on why there aren't more types (the reason
   for a change belongs in the entry's wording, not a new type), and direct answers
-  for **Dependencies** and **Known issues**. It also recommends a **section order**
-  (the order the six types are listed, kept consistent across releases) and leaves
-  entry order within a section to the author's judgment — closing #458, the
-  highest-reaction open request, without mandating an order or contradicting the
-  examples.
+  for **Dependencies** and **Known issues**. It also recommends a **section order
+  by urgency** — `Security`, `Removed`, `Changed`, `Deprecated`, `Fixed`, `Added`,
+  omitting empty sections — so what a reader must act on comes before what is
+  optional, kept consistent across releases, with entry order within a section left
+  to the author's judgment. This closes #458 (the highest-reaction open request)
+  and lands PR #706, which @olivierlacan slated for 2.0.
 - **`#breaking` — marking breaking changes (new).** A `**Breaking:**` marker on
   `Changed` / `Removed` entries rather than a new section, plus: name which
   interface your versioning scheme treats as stable.

--- a/docs/2.0.0-example-changelog.md
+++ b/docs/2.0.0-example-changelog.md
@@ -29,10 +29,13 @@ Versioning covers the public library API (the exported functions and their optio
 
 This release stabilizes the request API and removes the legacy callback interface deprecated in 1.4.0. Most projects only need to rename one option to upgrade; one larger change has a migration guide.
 
-### Added
+### Security
 
-- Automatic retries for failed idempotent requests, with exponential backoff. Configure it with the new `retry` option.
-- `Client.withTimeout(ms)` to set a per-request timeout.
+- CVE-2026-31840: redirects to a different host no longer forward the `Authorization` header, preventing credential leaks to untrusted destinations.
+
+### Removed
+
+- **Breaking:** removed the callback-style `request(url, callback)` form deprecated in 1.4.0. Pass a URL and await the returned promise instead.
 
 ### Changed
 
@@ -44,23 +47,16 @@ This release stabilizes the request API and removes the legacy callback interfac
 
 - `Client.setProxy()` is deprecated in favor of the `proxy` option passed to the constructor. It will be removed in 3.0.0.
 
-### Removed
-
-- **Breaking:** removed the callback-style `request(url, callback)` form deprecated in 1.4.0. Pass a URL and await the returned promise instead.
-
 ### Fixed
 
 - Requests no longer hang when the server closes a connection mid-response. The client now surfaces a `ConnectionClosed` error.
 
-### Security
-
-- CVE-2026-31840: redirects to a different host no longer forward the `Authorization` header, preventing credential leaks to untrusted destinations.
-
-## [1.4.0] - 2026-02-11
-
 ### Added
 
-- Promise-based `request()` that returns the response body. This is the supported form going forward.
+- Automatic retries for failed idempotent requests, with exponential backoff. Configure it with the new `retry` option.
+- `Client.withTimeout(ms)` to set a per-request timeout.
+
+## [1.4.0] - 2026-02-11
 
 ### Deprecated
 
@@ -69,6 +65,10 @@ This release stabilizes the request API and removes the legacy callback interfac
 ### Fixed
 
 - Query strings with repeated keys are now encoded correctly instead of keeping only the last value.
+
+### Added
+
+- Promise-based `request()` that returns the response body. This is the supported form going forward.
 
 ## [1.3.1] - 2025-11-30 [YANKED]
 
@@ -80,13 +80,13 @@ This release was yanked: the gzip fix below corrupted responses larger than 64 K
 
 ## [1.3.0] - 2025-11-18
 
-### Added
-
-- Support for `gzip` and `deflate` response compression.
-
 ### Changed
 
 - The default request timeout is now 30 seconds instead of unlimited, so a stalled server no longer blocks a request forever.
+
+### Added
+
+- Support for `gzip` and `deflate` response compression.
 
 [Unreleased]: https://github.com/acme/widget/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/acme/widget/compare/v1.4.0...v2.0.0

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -101,18 +101,25 @@ A short upgrade note can sit in the entry itself, such as "rename the `color` op
 
 ### Naming the part it touches {#areas}
 
-In a project with distinct parts (a command line and a library, a handful of modules, the areas of an app), an entry can say which part it changed by opening with the part's name and a colon:
+In a project with distinct parts or features, an entry can specify which was impacted on a change entry:
 
 ```
-- CLI: `brcat` alias for decoding concatenated streams.
-- Parser: recover from a truncated final chunk instead of raising.
+- CLI: `brcat` alias for decoding streams.
+- Parser: recover from a missing final chunk instead of raising.
 ```
 
-This is prose, not a new kind of change. The name reads as the start of the sentence, and it groups entries by area for anyone scanning: the same job the six types do by kind, on a second axis you define. Keep it a lead-in within the type, never a new `### CLI` heading. The six types are what every reader and tool can rely on, and a per-area heading fragments them. It pairs naturally with the per-component record a larger project already keeps.
+Similarly to change types they can group entries by area of focus. They shouldn't be used at at the same heading level as types but there may be situations where multiple changes relate to the same focus area. In that case nesting under a level-4 heading can work:
 
-Keep the names few, consistent, and drawn from words your readers know. A name is worth adding when it tells the reader something the entry does not already; skip it when the change is plainly about one thing. Like the `**Breaking:**` marker, this is an option, not a requirement.
+```
+### Added
+#### CLI
+- New `--verbose` flag for detailed output
+- New `--dry-run` flag that won't execute commands
+```
 
-An added benefit follows from writing these plainly. Because the names are consistent, a short script can group the changelog by area as easily as by version. It is the same "the changelog is the source" idea behind release notes, extended from one part of the history to one part of the product.
+Try to limit those areas and to be consistent. A name is worth adding when it tells readers something the entry doesn't; skip it when the change is plainly about one thing. Like the `**Breaking:**` marker, this is an option, not a requirement.
+
+An added benefit follows from writing these plainly. Because the names are consistent, a short script can group the changelog by area. As with release notes, the changelog remains the source, but in this case focused on the history of one area.
 
 ### Structuring a release {#releasing}
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -72,6 +72,10 @@ When a `Security` entry has a CVE identifier, lead with it so readers and securi
 - CVE-2024-12345: out-of-bounds read when parsing malformed input.
 ```
 
+A Security entry is a short, human-readable summary, not the full advisory. Keep it brief and link to the advisory (a CVE record, a security database entry, or your own security page) where readers and tools can find the affected versions, severity, and fix.
+
+Some projects also have formal ways they must disclose vulnerabilities (a security advisory database, or rules for certain products). A changelog does not replace those; publish the advisory where it belongs and point to it.
+
 <aside markdown="1">
 There are only six types on purpose. What kind of change it is goes in the type; why it matters goes in the wording of the entry, not in a new type.
 </aside>

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -54,9 +54,9 @@ People do. Anyone who uses or builds software wants to know what changed, and wh
 - `Fixed` for bug fixes.
 - `Added` for new features.
 
-The sections above are listed in order of urgency, most pressing first. Readers skim a changelog to find what affects them, and not every release has every type. An order that leads with new features can leave a security fix or a removal far down the list, where someone upgrading might miss it. Ordering by urgency puts what a reader must act on (a vulnerability, a removed or changed feature) above what is only good to know (a new feature or a minor fix).
+Changelog sections are listed in order of urgency since readers often skim a changelog to find what affects them. Starting with new features might make it harder to notice security fixes or important removals. Ordering by urgency puts what a reader must act on above what is only good to know.
 
-Keep this order in every release so readers always know where to look, and omit any section with no entries. The order is a recommendation, not a rule; if you prefer a different one, keep it consistent for the same reason. Within a section, order entries whichever way helps your readers most.
+If you prefer a different order for sections, try to keep it consistent across releases so readers know where to look. Omit any section with no entries instead of cluttering your changelog with empty sections. Within a section, order entries based on what's most useful to readers.
 
 Usually the right type is clear. Three of them cause the most questions:
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -47,14 +47,14 @@ People do. Anyone who uses or builds software wants to know what changed, and wh
 
 ### Types of changes {#types}
 
-- `Added` for new features.
+- `Security` for vulnerabilities.
+- `Removed` for now removed features.
 - `Changed` for changes in existing functionality.
 - `Deprecated` for soon-to-be removed features.
-- `Removed` for now removed features.
 - `Fixed` for bug fixes.
-- `Security` for vulnerabilities.
+- `Added` for new features.
 
-Keep these sections in the same order in every release, so readers always know where to look; not every release has every type. The order they are listed above is a sensible default, and the one the examples use. Within a section, order entries whichever way helps your readers most.
+These sections are ordered by urgency, most pressing first. What a reader must act on (security fixes, removals, and breaking changes) comes before what is optional, such as new features. Keep this order in every release, and omit any section with no entries, so readers always know where to look. Within a section, order entries whichever way helps your readers most.
 
 Usually the right type is clear. Three of them cause the most questions:
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -163,6 +163,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Stating the conventions you follow tells readers, and tools, what to expect. The first link declares the format; the second names your versioning scheme (Semantic Versioning here, but reference whichever you use). Pin the Keep a Changelog link to the version you follow, so it stays accurate as this page changes.
 
+Adopting a newer version of this format does not mean rewriting your history. Leave past entries as they are, apply the new conventions from your next release onward, and update the version in the link to match. Noting the switch in that release helps readers, for example a short summary line saying the changelog now follows Keep a Changelog 2.0.0. A changelog spans years and more than one version of these conventions, and old entries stay valid, so there is no need to redo them.
+
 ### Is a changelog the same as release notes? {#release-notes}
 
 No, although they draw from the same material. A changelog is the complete, ongoing record: every notable change, across every version, kept in one file in the repository and written plainly for anyone. Release notes are an announcement for a single release: a curated selection of its headline changes, often with upgrade steps and a marketing voice, published at release time. The changelog is the source; release notes are drawn from it and shaped for the announcement. Keep the changelog as the record, and write the release notes from it rather than maintaining two.

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -54,6 +54,8 @@ People do. Anyone who uses or builds software wants to know what changed, and wh
 - `Fixed` for bug fixes.
 - `Security` for vulnerabilities.
 
+Keep these sections in the same order in every release, so readers always know where to look; not every release has every type. The order they are listed above is a sensible default, and the one the examples use. Within a section, order entries whichever way helps your readers most.
+
 Usually the right type is clear. Three of them cause the most questions:
 
 - `Fixed`: the behavior was wrong, and is now correct.

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -54,7 +54,9 @@ People do. Anyone who uses or builds software wants to know what changed, and wh
 - `Fixed` for bug fixes.
 - `Added` for new features.
 
-These sections are ordered by urgency, most pressing first. What a reader must act on (security fixes, removals, and breaking changes) comes before what is optional, such as new features. Keep this order in every release, and omit any section with no entries, so readers always know where to look. Within a section, order entries whichever way helps your readers most.
+The sections above are listed in order of urgency, most pressing first. Readers skim a changelog to find what affects them, and not every release has every type. An order that leads with new features can leave a security fix or a removal far down the list, where someone upgrading might miss it. Ordering by urgency puts what a reader must act on (a vulnerability, a removed or changed feature) above what is only good to know (a new feature or a minor fix).
+
+Keep this order in every release so readers always know where to look, and omit any section with no entries. The order is a recommendation, not a rule; if you prefer a different one, keep it consistent for the same reason. Within a section, order entries whichever way helps your readers most.
 
 Usually the right type is clear. Three of them cause the most questions:
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -113,9 +113,9 @@ The square brackets around `[1.0.0]` make it a Markdown reference link. Resolve 
 [1.0.0]: https://github.com/your/project/releases/tag/v1.0.0
 ```
 
-`[Unreleased]` compares the latest tag to `HEAD` (the current state of your code), so it always shows what has accrued since the last release, and the oldest version links to its tag, since there is nothing earlier to compare it with. Now every version is tied to its tag and links to the exact diff of what changed: the same association a hosted release page makes for you, kept in a file you own instead of a host's database. Any host exposes tag and comparison URLs, so the pattern works wherever your code lives, and the link stays out of the heading, so the changelog still reads cleanly.
+`[Unreleased]` compares the latest tag to `HEAD` (the current state of your code), so it always shows what has changed since the last release. The oldest version links to its tag, since there is nothing earlier to compare it with. Every version is then tied to its tag and links to the exact diff of what changed. Any host exposes tag and comparison URLs, so this works wherever your code lives, and the link stays out of the heading, so the changelog still reads cleanly.
 
-When you cut a release, rename `Unreleased` to the new version in both the heading and its link, then add a fresh, empty `Unreleased` section pointing at `HEAD`.
+When you release a version, rename `Unreleased` to the new version in both the heading and its link, then add a fresh, empty `Unreleased` section pointing at `HEAD`.
 
 A version may open with a short summary before the typed sections: a sentence or two on the theme of the release or a notable change. This is optional. Use it when a release is worth introducing, and skip it otherwise.
 
@@ -150,13 +150,13 @@ Stating the conventions you follow tells readers, and tools, what to expect. The
 
 ### Is a changelog the same as release notes? {#release-notes}
 
-No, although they draw from the same material. A changelog is the complete, ongoing record: every notable change, across every version, kept in one file in the repository and written plainly for anyone. Release notes are an announcement for a single release: a curated selection of its headline changes, often with upgrade steps and a marketing voice, published when that version ships. The changelog is the source; release notes are drawn from it and shaped for the announcement. Keep the changelog as the record, and write the release notes from it rather than maintaining two.
+No, although they draw from the same material. A changelog is the complete, ongoing record: every notable change, across every version, kept in one file in the repository and written plainly for anyone. Release notes are an announcement for a single release: a curated selection of its headline changes, often with upgrade steps and a marketing voice, published at release time. The changelog is the source; release notes are drawn from it and shaped for the announcement. Keep the changelog as the record, and write the release notes from it rather than maintaining two.
 
 This does not have to mean doing the work twice. At release time, the version's section in the changelog is already the draft: copy it into the release, and expand it only if the announcement wants more. Because every version sits under a predictable `## [x.y.z]` heading, a small script can extract that section and create the release without anyone retyping it.
 
-A host will offer to do this for you. See that offer for what it is. Their release systems attach notes to a tag, notify watchers, and collect build files; often even generating the notes (from merged pull requests or commit messages). But everything is stored in the host's database, not your repository. These releases don't travel with the repository and follow you to another host: the convenience is the hook. Meanwhile, your changelog goes where your code goes; what a host generates and keeps for you does not, and you lose it the day you leave.
+A host will offer to do this for you. Its release system attaches notes to a tag, notifies watchers, collects build files, and can even generate the notes from merged pull requests or commit messages. But the result lives in the host's database, not your repository. Those notes do not travel with the code, so if you move to another host, they do not come with you. Your changelog does, because it is a file in the repository.
 
-You can treat a generated draft as a starting point, but keep `CHANGELOG.md` as the canonical record. You can then generate host-specific release posts from it. A changelog file brings the same information these systems present, except it reads offline. You still benefit from the host's reach (notifications, a visible page, attached downloads) without entirely depending on it to hold your project's history.
+You can treat a generated draft as a starting point, but keep `CHANGELOG.md` as the canonical record and generate host-specific release posts from it. That way you still get the host's reach (notifications, a visible page, attached downloads), and the full history stays in a file you control and can read offline.
 
 ## What makes a changelog worse? {#bad-practices}
 
@@ -218,7 +218,7 @@ A single file is usually fine, even a long one; many projects keep decades of hi
 
 A shared `Unreleased` section is convenient, but it may lead to merge conflicts when branches are frequently merged. While keeping entries short and on the same branch as changes can help, when conflicts are frequent you can tell your version control system to retain conflicting lines with a union merge (e.g. `merge=union` in `.gitattributes` file).
 
-Higher-volume projects can also keep unreleased entries in a separate file inside a directory such as `changelog.d/`. Branches avoid conflict by not editing the same section of the changelog file. At release time the files can be combined into the `CHANGELOG.md` and removed from the subdirectory. This helps with scalability but it does adds complexity. It's best to start with a shared `Unreleased` section; add a union merge if conflicts become tedious; and evolve to per-branch files when it becomes unavoidable.
+Higher-volume projects can also keep unreleased entries in a separate file inside a directory such as `changelog.d/`. Branches avoid conflict by not editing the same section of the changelog file. At release time the files can be combined into the `CHANGELOG.md` and removed from the subdirectory. This helps with scalability but it does add complexity. It's best to start with a shared `Unreleased` section; add a union merge if conflicts become tedious; and evolve to per-branch files when it becomes unavoidable.
 
 ### What about monorepos? {#monorepos}
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -99,6 +99,21 @@ Say what breaks. The word means little until readers know which interface you ke
 
 A short upgrade note can sit in the entry itself, such as "rename the `color` option to `theme`." When the steps are substantial, link to them (a migration guide or the release notes) rather than spelling them out here. A long procedure buries what changed and turns a scannable record into a how-to: a different kind of document, for a narrower audience. Keep the `**Breaking:**` marker on the entry itself, within its type, rather than collecting breaks into a separate section, so anyone scanning `Changed` or `Removed` sees them in place.
 
+### Naming the part it touches {#areas}
+
+In a project with distinct parts (a command line and a library, a handful of modules, the areas of an app), an entry can say which part it changed by opening with the part's name and a colon:
+
+```
+- CLI: `brcat` alias for decoding concatenated streams.
+- Parser: recover from a truncated final chunk instead of raising.
+```
+
+This is prose, not a new kind of change. The name reads as the start of the sentence, and it groups entries by area for anyone scanning: the same job the six types do by kind, on a second axis you define. Keep it a lead-in within the type, never a new `### CLI` heading. The six types are what every reader and tool can rely on, and a per-area heading fragments them. It pairs naturally with the per-component record a larger project already keeps.
+
+Keep the names few, consistent, and drawn from words your readers know. A name is worth adding when it tells the reader something the entry does not already; skip it when the change is plainly about one thing. Like the `**Breaking:**` marker, this is an option, not a requirement.
+
+An added benefit follows from writing these plainly. Because the names are consistent, a short script can group the changelog by area as easily as by version. It is the same "the changelog is the source" idea behind release notes, extended from one part of the history to one part of the product.
+
 ### Structuring a release {#releasing}
 
 Keep an `Unreleased` section at the top to collect upcoming changes. It shows readers what to expect, and at release time you move its contents into a new version. Starting on a project that has no changelog? Begin here, recording notable changes from now on. Reconstructing past releases from your version history is also worthwhile if you want a fuller record; either is fine.

--- a/test/prose_lint_test.rb
+++ b/test/prose_lint_test.rb
@@ -26,10 +26,22 @@ class ProseLintTest < Minitest::Test
     assert_empty errors("The relationship between commits and entries.")
   end
 
-  def test_flags_named_idioms_and_house_style
+  def test_flags_named_idioms
     assert_includes ids("When you cut a release, rename it."), "idiom"
     assert_includes ids("Check that the file is well-formed."), "well-formed"
-    assert_includes ids("This is a break — a real one."), "em-dash"
+  end
+
+  def test_a_lone_em_dash_is_allowed_but_several_in_a_sentence_warn
+    # A single em-dash is a legitimate break, not a finding.
+    assert_empty ProseLint.lint("This is a break — a real one.")
+    # Two or more in one sentence read as a bracketed aside a colon or commas
+    # would replace: warn, never error.
+    findings = ProseLint.lint("The tool — a small script — runs fine.")
+    assert(findings.any? { |f| f.rule == "em-dash-aside" && f.severity == :warn })
+    assert_empty findings.select { |f| f.severity == :error }
+    # The aside count is measured per sentence, so one dash each in two
+    # sentences stays clean.
+    assert_empty ProseLint.lint("One break — here. Another break — there.")
   end
 
   def test_just_is_a_warning_not_an_error

--- a/test/prose_lint_test.rb
+++ b/test/prose_lint_test.rb
@@ -1,0 +1,67 @@
+require "minitest/autorun"
+require_relative "../tools/prose_lint"
+
+# The prose lint encodes docs/tone-and-voice.md so the English spec source is
+# held to it in CI, not just by a reviewer's eye. These tests pin two things:
+# the rules fire on known-bad prose, and the live 2.0 page passes clean (so the
+# lint is a real gate, not decoration).
+class ProseLintTest < Minitest::Test
+  def ids(text)
+    ProseLint.lint(text).map(&:rule)
+  end
+
+  def errors(text)
+    ProseLint.lint(text).select { |f| f.severity == :error }
+  end
+
+  def test_flags_gatekeeping_words
+    assert_includes ids("This is obviously fine."), "gatekeeping"
+    assert_includes ids("You simply add a line."), "gatekeeping"
+    assert_includes ids("Of course you know this."), "gatekeeping"
+    assert_includes ids("It is trivially easy."), "gatekeeping"
+  end
+
+  def test_flags_ship_but_not_relationship
+    assert_includes ids("You ship it on Friday."), "ship"
+    assert_empty errors("The relationship between commits and entries.")
+  end
+
+  def test_flags_named_idioms_and_house_style
+    assert_includes ids("When you cut a release, rename it."), "idiom"
+    assert_includes ids("Check that the file is well-formed."), "well-formed"
+    assert_includes ids("This is a break — a real one."), "em-dash"
+  end
+
+  def test_just_is_a_warning_not_an_error
+    findings = ProseLint.lint("This is just a note.")
+    assert(findings.any? { |f| f.rule == "just" && f.severity == :warn })
+    assert_empty findings.select { |f| f.severity == :error }
+  end
+
+  def test_ignores_code_links_and_suppressed_lines
+    # Banned words inside inline code or a URL are not prose.
+    assert_empty errors("Use the `--ship` flag.")
+    assert_empty errors("[guide](https://example.com/of-course) explains it.")
+    # A fenced block is skipped entirely.
+    fenced = "```\nyou simply ship it\n```\n"
+    assert_empty errors(fenced)
+    # The per-line marker suppresses that line.
+    assert_empty errors("This is obviously fine. <!-- prose-lint-ignore -->")
+  end
+
+  def test_long_sentence_warns_but_enumerations_do_not
+    run_on = (["word"] * 60).join(" ") + "."
+    assert(ProseLint.lint(run_on).any? { |f| f.rule == "long-sentence" })
+
+    enumeration = "Do this: " + (["a"] * 60).join("; ") + "."
+    assert_empty ProseLint.lint(enumeration).select { |f| f.rule == "long-sentence" }
+  end
+
+  def test_the_live_2_0_page_is_clean
+    findings = ProseLint.lint_file(File.expand_path("../source/en/2.0.0/index.html.md", __dir__))
+    problems = findings.select { |f| f.severity == :error }
+    assert_empty problems,
+      "2.0 page has prose-lint errors:\n" +
+        problems.map { |f| "  line #{f.line}: #{f.rule} \"#{f.match}\"" }.join("\n")
+  end
+end

--- a/tools/prose_lint.rb
+++ b/tools/prose_lint.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+# Pure, framework-free prose lint for the English spec source. It enforces the
+# rules in docs/tone-and-voice.md so they hold automatically instead of relying
+# on a reviewer catching them, the way translation_coverage.rb --lint guards the
+# translations. It reads the same Markdown a translator would, skips code and
+# link machinery, and reports two severities:
+#
+#   :error  high-confidence tone or house-style breaks that should fail CI
+#           (em/en dashes, "ship" where "release" is meant, gatekeeping words
+#           the guide bans, a handful of idioms it calls out by name)
+#   :warn   context-dependent smells worth a human glance but not a build
+#           failure on their own (a bare "just", a very long sentence)
+#
+# Scope is the 2.0+ Markdown pages (source/en/*/index.html.md). The older HAML
+# pages keep the earlier, jokier voice on purpose (they are pinned to their era),
+# so they are deliberately out of scope. Run via `bin/rake prose:lint`; the
+# contract is pinned in test/prose_lint_test.rb.
+#
+# Suppress a single false positive by putting `<!-- prose-lint-ignore -->`
+# anywhere on the offending line. The comment does not render in the built page.
+module ProseLint
+  Finding = Struct.new(:line, :severity, :rule, :match, :hint, keyword_init: true)
+
+  IGNORE_MARKER = "prose-lint-ignore"
+
+  # Only flag a long sentence past this many words, and never when it is a
+  # semicolon-separated enumeration (those read as a list, not a run-on). The
+  # threshold sits above the longest legitimate sentence on the 2.0 page so the
+  # warning means something when it does fire.
+  LONG_SENTENCE_WORDS = 45
+
+  # Each rule: a matcher, a severity, a short id, and a hint naming the fix. The
+  # matchers are case-insensitive and word-bounded so "relationship" never trips
+  # the "ship" rule. Order is report order.
+  RULES = [
+    # --- House style: the 2.0 page uses no em/en dashes (commas, colons, or
+    # parentheses instead), so a stray one is almost always a paste artifact. ---
+    { id: "em-dash", severity: :error, re: /[—–]/,
+      hint: "no em/en dashes on the page; use a comma, colon, or parentheses" },
+
+    # --- Gatekeeping (guide principle 2): words that tell a reader they should
+    # already understand. "just" is the same family but too common to fail on,
+    # so it is a warning below. ---
+    { id: "gatekeeping", severity: :error, re: /\bobvious(ly)?\b/i,
+      hint: "gatekeeping; show it is simple with a short sentence instead" },
+    { id: "gatekeeping", severity: :error, re: /\bsimply\b/i,
+      hint: "gatekeeping; cut it or rephrase" },
+    # "trivially" is the gatekeeping adverb the guide lists; a plain "trivial
+    # change" means a minor one and is fine, so match only the adverb.
+    { id: "gatekeeping", severity: :error, re: /\btrivially\b/i,
+      hint: "gatekeeping; say what makes it small instead" },
+    { id: "gatekeeping", severity: :error, re: /\bof course\b/i,
+      hint: "gatekeeping; cut it" },
+    { id: "gatekeeping", severity: :error, re: /\beveryone knows\b/i,
+      hint: "gatekeeping; do not assume the reader knows" },
+    { id: "gatekeeping", severity: :error, re: /\bas you(?:'d| would) expect\b/i,
+      hint: "gatekeeping; state it plainly instead" },
+
+    # --- Jargon and idioms the guide replaces with plain verbs. ---
+    { id: "ship", severity: :error, re: /\bship(s|ped|ping)?\b/i,
+      hint: "use 'release', not 'ship'" },
+    { id: "well-formed", severity: :error, re: /\bwell-formed\b/i,
+      hint: "use 'formatted correctly'" },
+    { id: "idiom", severity: :error, re: /\bcut a release\b/i,
+      hint: "idiom; use 'release a version' or 'at release time'" },
+    { id: "idiom", severity: :error, re: /\bbolt(ed)? on\b/i,
+      hint: "idiom; use 'add'" },
+    { id: "idiom", severity: :error, re: /\bchase down\b/i,
+      hint: "idiom; use 'find'" },
+    { id: "idiom", severity: :error, re: /\bthe hook\b/i,
+      hint: "metaphor; state the point plainly" },
+
+    # --- Warnings: real but context-dependent. ---
+    { id: "just", severity: :warn, re: /\bjust\b/i,
+      hint: "often filler; if it means 'merely', cut it" },
+    { id: "call-out", severity: :warn, re: /\bcall(s|ed|ing)? out\b/i,
+      hint: "idiom; prefer 'highlight'" }
+  ].freeze
+
+  module_function
+
+  # Lint one file. Returns an array of Finding, in file order.
+  def lint_file(path)
+    lint(File.read(path, encoding: "UTF-8"))
+  end
+
+  # Lint Markdown text. Skips fenced code blocks and link-reference definitions,
+  # strips inline code spans and URLs from prose before matching (so a banned
+  # word inside `code` or a link target is not flagged), and honors the
+  # per-line ignore marker.
+  def lint(text)
+    findings = []
+    in_fence = false
+
+    text.each_line.with_index(1) do |raw, lineno|
+      line = raw.chomp
+
+      if line =~ /\A\s*(```|~~~)/
+        in_fence = !in_fence
+        next
+      end
+      next if in_fence
+      next if line.include?(IGNORE_MARKER)
+      next if link_definition?(line)
+
+      prose = scrub(line)
+      next if prose.strip.empty?
+
+      RULES.each do |rule|
+        prose.scan(rule[:re]) do
+          findings << Finding.new(
+            line: lineno, severity: rule[:severity], rule: rule[:id],
+            match: Regexp.last_match(0), hint: rule[:hint]
+          )
+        end
+      end
+
+      long_sentences(prose).each do |sentence, words|
+        findings << Finding.new(
+          line: lineno, severity: :warn, rule: "long-sentence",
+          match: "#{words} words", hint: truncate(sentence)
+        )
+      end
+    end
+
+    findings
+  end
+
+  # A Markdown reference-link definition line, e.g. `[semver]: https://...`.
+  def link_definition?(line)
+    line.match?(/\A\s*\[[^\]]+\]:\s+\S/)
+  end
+
+  # Remove the parts of a prose line that are not authored prose: inline code
+  # spans, autolinks/URLs, and the URL half of an inline `[text](url)` link
+  # (the visible text stays). Leaves the rest for matching.
+  def scrub(line)
+    line
+      .gsub(/`[^`]*`/, " ")            # inline code
+      .gsub(/\]\([^)]*\)/, "] ")       # inline-link targets, keep the [text]
+      .gsub(%r{https?://\S+}, " ")     # bare URLs
+  end
+
+  # Sentences over the word threshold, excluding semicolon enumerations. Returns
+  # [sentence, word_count] pairs.
+  def long_sentences(prose)
+    prose.split(/(?<=[.!?])\s+/).filter_map do |sentence|
+      next if sentence.count(";") >= 2 # a list, not a run-on
+      words = sentence.split(/\s+/).count { |w| w =~ /[[:alpha:]]/ }
+      [sentence, words] if words > LONG_SENTENCE_WORDS
+    end
+  end
+
+  def truncate(str, max = 60)
+    str.length > max ? "#{str[0, max].rstrip}..." : str
+  end
+
+  # Human-readable report for a set of [path, Finding] pairs.
+  def format_findings(pairs)
+    pairs.map do |path, f|
+      "#{path}:#{f.line}: [#{f.severity}] #{f.rule}: \"#{f.match}\" — #{f.hint}"
+    end.join("\n")
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  strict = ARGV.include?("--strict")
+  paths = ARGV.reject { |a| a.start_with?("--") }
+  paths = Dir["source/en/*/index.html.md"].sort if paths.empty?
+
+  pairs = paths.flat_map { |p| ProseLint.lint_file(p).map { |f| [p, f] } }
+  errors = pairs.count { |(_, f)| f.severity == :error }
+  warns = pairs.count { |(_, f)| f.severity == :warn }
+
+  puts ProseLint.format_findings(pairs) unless pairs.empty?
+  summary = "prose-lint: #{errors} error(s), #{warns} warning(s) across #{paths.size} file(s)"
+  puts(pairs.empty? ? "prose-lint: clean (#{paths.size} file(s))" : summary)
+
+  exit 1 if errors.positive? || (strict && warns.positive?)
+end

--- a/tools/prose_lint.rb
+++ b/tools/prose_lint.rb
@@ -7,10 +7,11 @@
 # link machinery, and reports two severities:
 #
 #   :error  high-confidence tone or house-style breaks that should fail CI
-#           (em/en dashes, "ship" where "release" is meant, gatekeeping words
-#           the guide bans, a handful of idioms it calls out by name)
+#           ("ship" where "release" is meant, gatekeeping words the guide bans,
+#           a handful of idioms it calls out by name)
 #   :warn   context-dependent smells worth a human glance but not a build
-#           failure on their own (a bare "just", a very long sentence)
+#           failure on their own (a bare "just", a very long sentence, several
+#           em-dashes piled into one sentence as bracketed asides)
 #
 # Scope is the 2.0+ Markdown pages (source/en/*/index.html.md). The older HAML
 # pages keep the earlier, jokier voice on purpose (they are pinned to their era),
@@ -30,15 +31,17 @@ module ProseLint
   # warning means something when it does fire.
   LONG_SENTENCE_WORDS = 45
 
+  # Em-dashes are welcome for a genuine break. What reads poorly is piling
+  # several into one sentence as bracketed asides, where a colon, commas, or
+  # parentheses would be cleaner, so warn only past this many in one sentence.
+  # A lone em-dash never fires.
+  EM_DASH = "—"
+  MAX_EM_DASHES_PER_SENTENCE = 1
+
   # Each rule: a matcher, a severity, a short id, and a hint naming the fix. The
   # matchers are case-insensitive and word-bounded so "relationship" never trips
   # the "ship" rule. Order is report order.
   RULES = [
-    # --- House style: the 2.0 page uses no em/en dashes (commas, colons, or
-    # parentheses instead), so a stray one is almost always a paste artifact. ---
-    { id: "em-dash", severity: :error, re: /[—–]/,
-      hint: "no em/en dashes on the page; use a comma, colon, or parentheses" },
-
     # --- Gatekeeping (guide principle 2): words that tell a reader they should
     # already understand. "just" is the same family but too common to fail on,
     # so it is a warning below. ---
@@ -122,6 +125,14 @@ module ProseLint
           match: "#{words} words", hint: truncate(sentence)
         )
       end
+
+      dash_heavy_sentences(prose).each do |count|
+        findings << Finding.new(
+          line: lineno, severity: :warn, rule: "em-dash-aside",
+          match: "#{count} em-dashes",
+          hint: "several em-dashes in one sentence; a colon, commas, or parentheses may read cleaner"
+        )
+      end
     end
 
     findings
@@ -149,6 +160,16 @@ module ProseLint
       next if sentence.count(";") >= 2 # a list, not a run-on
       words = sentence.split(/\s+/).count { |w| w =~ /[[:alpha:]]/ }
       [sentence, words] if words > LONG_SENTENCE_WORDS
+    end
+  end
+
+  # Sentences leaning on em-dashes as bracketed asides. A lone em-dash is fine;
+  # two or more in one sentence is the excessive apposition a colon or commas
+  # usually replace. Returns the em-dash count for each offending sentence.
+  def dash_heavy_sentences(prose)
+    prose.split(/(?<=[.!?])\s+/).filter_map do |sentence|
+      count = sentence.count(EM_DASH)
+      count if count > MAX_EM_DASHES_PER_SENTENCE
     end
   end
 


### PR DESCRIPTION
## Summary

Refinements to the 2.0 guidance from a review of the page against `docs/tone-and-voice.md` and the repo's issue history, plus a new prose lint that keeps the page held to the voice guide automatically. The headline addition is a new optional convention, **Naming the part it touches (`#areas`)**. All prose passes the new `bin/rake prose:lint` (also wired into CI).

## New guidance: Naming the part it touches (`#areas`)

An entry can name which part of a project it changed with a `Name:` lead-in *inside* a type:

```
- CLI: `brcat` alias for decoding concatenated streams.
- Parser: recover from a truncated final chunk instead of raising.
```

It's prose, not a new change type, and never a `### CLI` heading: the six types stay the set and stay parseable. It's optional, like `**Breaking:**`, and pairs with the per-component changelog guidance in `#monorepos`.

**Which requests this addresses** (from an audit of issues/PRs for "which part changed" categorization):

- **Fully — #550:** the clearest match; grouping entries by sub-component inside a type is exactly what that thread asked to have blessed.
- **Partially — #299 (monorepos), #143 (submodules):** `#areas` names the part inline and pairs with per-component changelogs, but does not bless a `### Component` heading.
- **Prior art, same mechanism / different axis — #111 (subtypes), #98 (prefix convention):** both proposed the inline-prefix idea for change *kind*; `#areas` is the "which part" axis, and the section says so explicitly to head off the recurring confusion.
- **Deliberately not addressed:** requests for new *kinds* of change (#369, #645, #665, #134, #272, and the ordering ask #458) — `#areas` keeps the six types.

(GitHub Discussions weren't reachable via the API; a few older numbers 404, likely converted to Discussions.)

## Also in this branch

- **Change-type order by urgency (`#types`)** — lands @abatko's #706 (`Security`, `Removed`, `Changed`, `Deprecated`, `Fixed`, `Added`; omit empty sections), with prose that justifies the order and keeps it a recommendation, not a rule. Examples reordered to match. Resolves #458. @abatko credited via a commit trailer and a note on #706.
- **Security entry as a pointer** — a `Security` entry summarizes and links to the advisory (a CVE record, a security database, or your own security page); projects with formal disclosure duties meet those elsewhere and point to them. Vendor-neutral, names no standards.
- **Plainer voice in `#releasing` / `#release-notes`** — fixes wording that broke the voice guide (`ship`→release, `cut a release`, "the convenience is the hook", a grammar slip) and states the host lock-in point once instead of four times.
- **`prose:lint`** — a dependency-free Ruby lint (`tools/prose_lint.rb`) enforcing `docs/tone-and-voice.md` on the English source, wired into CI with a test that also asserts the live 2.0 page is clean.

## Coordination with the release PR #736

This overlaps #736 and needs reconciling (opening now, reconcile later, by decision):

- Both edit `source/en/2.0.0/index.html.md` and the same CHANGELOG `Format:` bullet.
- #736 re-dates 2.0.0 to 2026-08-24; this branch's CHANGELOG reorder sits on the current `main` date (2026-06-07).
- #736 adds tone rule #9 (contractions are the default) and applies it; the prose here predates that and should adopt contractions on reconcile.
- Worth noting this branch **fixes `"cut a release"`, which #736 still contains**, and **delivers #458**, which #736's own release checklist lists as a not-yet-included candidate — so this work belongs in the 2.0 release.

Whichever of the two merges first, the other rebases onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNNteJMKHMQ2J8P4ozFVFi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNNteJMKHMQ2J8P4ozFVFi)_