### PR TITLE
Restore an opinionated, first-person voice to the 2.0.0 page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The tagline is now "Tell the story of your project's evolution." The 2.0.0
+  line, "Clearly document the evolution of your projects," read like a product
+  page.
 - The 2.0.0 page reads less like a manual. First-person framing and direct
   address are back where the guidance is an opinion, transition sentences are
   gone, and choosing between `Fixed`, `Changed`, and `Security` is explained

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The "Changelog basics" cards no longer shrink as the window grows. Between
+  1248px and 1440px the row collapsed into the reading column to clear the
+  table of contents, leaving the cards narrower than they were at 1200px and
+  wrapping their headings. The row now grows continuously across that range,
+  and card headings are sized against the card so they stay on one line.
 - Older spec pages no longer display an example changelog written to newer
   conventions than the page describes: each page's example is now pinned to
   its own version's last release, derived at build time from this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The 2.0.0 page reads less like a manual. First-person framing and direct
+  address are back where the guidance is an opinion, transition sentences are
+  gone, and choosing between `Fixed`, `Changed`, and `Security` is explained
+  with an example of each instead of an if-then procedure. The structure and
+  section links are unchanged.
+
 ### Fixed
 
 - Older spec pages no longer display an example changelog written to newer

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -53,12 +53,14 @@ out.
 The signature line is new in 2.0.0:
 
 - **Was:** "Don't let your friends dump git logs into changelogs."
-- **Now:** "Clearly document the evolution of your projects."
+- **Now:** "Tell the story of your project's evolution."
 
 It drives the hero subtitle and the page's meta/Open Graph description, so
 translators should translate the _new_ line. The old one was git-centric and
-leaned on an English idiom; the new one is active, leads with clarity, and is
-plainer to translate. Older versions keep the original tagline.
+leaned on an English idiom. 2.0.0 first replaced it with "Clearly document the
+evolution of your projects," which was plain but read like a product page; the
+current line keeps the plainness and says what a changelog is for. Older
+versions keep the original tagline.
 
 ## At a glance
 

--- a/docs/2.0.0-changes.md
+++ b/docs/2.0.0-changes.md
@@ -42,9 +42,11 @@ into a structured guide:
   large files, monorepos, linking; then standard, scope, contributing.
 - **`#references`** replaces the personal "Conversations" footer.
 
-The `#frequently-asked-questions` wrapper heading is gone, along with its first-
-person framing. The voice is now plainer and less about the author — see
-`docs/tone-and-voice.md` for the guide that drives this.
+The `#frequently-asked-questions` wrapper heading is gone. The voice is plainer
+than 1.1.0's, but it still speaks in the first person where the guidance is an
+opinion, and it still addresses the reader directly — see `docs/tone-and-voice.md`
+for the guide that drives this, including the machine-flavored patterns it rules
+out.
 
 ## The tagline changed
 
@@ -78,8 +80,8 @@ plainer to translate. Older versions keep the original tagline.
 ### Working with the change types
 
 - **`#types` expanded.** Beyond the six-type list, it now resolves the boundary
-  people ask about most — `Fixed` vs `Changed` vs `Security` — with a "was the old
-  behavior a bug?" test, an **aside** on why there aren't more types (the reason
+  people ask about most — `Fixed` vs `Changed` vs `Security` — with a concrete
+  example of each, an **aside** on why there aren't more types (the reason
   for a change belongs in the entry's wording, not a new type), and direct answers
   for **Dependencies** and **Known issues**. The **Security** guidance also frames
   an entry as a pointer, not the advisory: keep it a short summary, link to the
@@ -157,9 +159,9 @@ plainer to translate. Older versions keep the original tagline.
 - **`#scope` — what Keep a Changelog won't do (new).** The non-goals: no growing the
   type set, no machine format/schema/required layout, no becoming a tool or runtime,
   no single-vendor lock-in.
-- **`#references` (new).** Replaces the first-person "Conversations" footer with a
-  short, synthesized note: how the convention grew (with a link to its own
-  changelog) and the podcast, the convention's reach (languages and project count),
+- **`#references` (new).** Replaces the "Conversations" footer with a short
+  note: how the convention grew (with a link to its own changelog) and the
+  podcast, the convention's reach (languages and project count),
   named adopters (NASA, the UK's National Archives, the Wikimedia Foundation,
   Cloudflare, Unity), and its research citations. Written to be easy to translate.
 
@@ -177,7 +179,7 @@ plainer to translate. Older versions keep the original tagline.
 | `#filename`             | Adds the rebuttal to "a changelog should list _all_ changes" (version control already does that).                                          |
 | `#yanked`               | Plainer wording; same guidance.                                                                                                            |
 | `#rewrite`              | Adds: note the date you updated an entry after release.                                                                                    |
-| `#contribute`           | Humbler, less first-person; "one carefully considered opinion."                                                                            |
+| `#contribute`           | Humbler; still "my carefully considered opinion," and still asks the reader to pitch in.                                                   |
 
 ## Merged / renamed / removed
 

--- a/docs/tone-and-voice.md
+++ b/docs/tone-and-voice.md
@@ -59,8 +59,9 @@ translate, easy to apply, and easy to trust.
    propositions or textbook neutrality. Keep memorable, opinionated wording
    when it does not cost clarity. The original tagline, _"Don't let your
    friends dump git logs into changelogs"_, was retired because it leaned on an
-   English idiom, not because it had an opinion. Whatever replaces it should
-   still take a position.
+   English idiom, not because it had an opinion. Its replacement, _"Tell the
+   story of your project's evolution"_, is plain and still says what a
+   changelog is for.
 10. **Keep the first person and direct address.** "I", "we", and "you" are not
     flaws to edit out. This is a community-driven opinion written by people, not
     an ISO standard, and the voice should feel like it comes from humans, for

--- a/docs/tone-and-voice.md
+++ b/docs/tone-and-voice.md
@@ -2,6 +2,14 @@
 
 How we write Keep a Changelog, and the standard the 2.0 rewrite is held to.
 
+Two failure modes bracket this guide. On one side is the in-group voice: jokes,
+idioms, and shorthand that reward insiders and leave everyone else out. On the
+other is the sanitized voice: prose so careful and generic that it could have
+been written by a committee, a marketing department, or a language model. Keep
+a Changelog has drifted toward both at different times. The guide steers
+between them: plain enough for anyone, and still recognizably written by
+people who care.
+
 ## Who we write for
 
 Keep a Changelog says changelogs are _for humans, not machines_. The same belief
@@ -43,14 +51,37 @@ translate, easy to apply, and easy to trust.
    changelog, entry, version, release. Don't vary it for style.
 8. **Warm, not in-group.** A little personality is welcome — never at the cost of
    clarity, never aimed at one person, and never the kind of joke or reference
-   that rewards insiders and leaves everyone else out. This is the voice 2.0 moves
-   toward, away from the older, jokier tone.
+   that rewards insiders and leaves everyone else out. Plain does not mean flat.
+9. **Opinionated peer, not corporate textbook.** Write as if you are explaining
+   best practices to a peer you respect, and say what you think. Keep a Changelog
+   exists because someone was fed up with git logs passed off as changelogs, and
+   the page should still sound like it. Do not reach for sanitized value
+   propositions or textbook neutrality. Keep memorable, opinionated wording
+   when it does not cost clarity. The original tagline, _"Don't let your
+   friends dump git logs into changelogs"_, was retired because it leaned on an
+   English idiom, not because it had an opinion. Whatever replaces it should
+   still take a position.
+10. **Keep the first person and direct address.** "I", "we", and "you" are not
+    flaws to edit out. This is a community-driven opinion written by people, not
+    an ISO standard, and the voice should feel like it comes from humans, for
+    humans. Say "we recommend" and "you can", not "it is recommended" and "one
+    may". Cut a first-person passage only when it is about the author rather
+    than the reader.
+11. **No buffer sentences.** Delete any sentence that exists only to bridge two
+    ideas or to announce what comes next: _"Here are a few ways to think about
+    this."_ _"Usually the right type is clear. Three of them cause the most
+    questions:"_ _"A few habits make a changelog less useful."_ If the list or
+    paragraph that follows makes sense without the sentence, the sentence goes.
+12. **No algorithmic phrasing.** When helping a reader choose between options,
+    do not spell out the exact thought process as a flowchart: _"If it was a
+    bug, use Fixed. If it was intentional, use Changed."_ Give the distinction
+    and a brief, concrete example, then trust the reader to apply it.
 
 ## Do / don't
 
 | Don't                                                              | Do                                           |
 | ------------------------------------------------------------------ | -------------------------------------------- |
-| "most of the time the right type is obvious"                       | "usually the right type is clear"            |
+| "most of the time the right type is obvious"                       | (delete it, or say which types are confused) |
 | "some projects ship continuously"                                  | "some projects release continuously"         |
 | "check that the file is well-formed"                               | "check that the file is formatted correctly" |
 | "take the chore out of it, as long as it doesn't become the chore" | "use it for mechanical tasks"                |
@@ -58,6 +89,36 @@ translate, easy to apply, and easy to trust.
 | "if your project leans on coding agents"                           | "if your project uses coding agents"         |
 | phrasal-verb idioms (bolt on, call out, chase down)                | plain verbs (add, highlight, find)           |
 | "if conflicts get tedious"                                         | "if conflict becomes tedious"
+| a tagline that could sit on any product page                       | a line that takes a position on what a changelog is for |
+| "Usually the right type is clear. Three of them cause the most questions:" | (delete it; start the list)              |
+| "If it was a bug, use `Fixed`. If it was intentional, use `Changed`." | "A crash is `Fixed`. A new default is `Changed`." |
+| "It is recommended that the changelog be kept in the repository."    | "Keep the changelog in the repository."      |
+| "One carefully considered opinion"                                  | "My carefully considered opinion"            |
+
+## Tells of machine-written prose
+
+Language models helped edit the 2.0 page, and their defaults leaked into it: a
+sterile tagline, flowchart explanations, transition sentences that say nothing,
+and every opinion flattened into neutral instruction. These are the patterns to
+watch for, whether the draft came from a model or from a tired human.
+
+- **Generic value propositions.** A tagline or opening that could sit on any
+  product's landing page. If it has no opinion, it is not ours.
+- **Buffer and transition sentences.** "Usually the right type is clear."
+  "There are a few ways to approach this." "Two other requests are common:"
+  They pad, and they dilute.
+- **Flowchart explanations.** "If X, use A. If Y, use B." A reader is not a
+  branch statement; give the distinction and an example.
+- **Impersonal hedging.** "It is recommended", "one might consider", "can be
+  useful". Say who recommends it and why, in the first person if that is who.
+- **Over-tidy structure.** Every idea in a labeled bucket, every section the
+  same shape, no narrative between them. Structure should serve the reader's
+  questions, not a table of contents.
+- **Symmetry for its own sake.** Three balanced bullets where two honest ones
+  would do.
+
+Plainness is still the goal. The fix for a machine-flavored sentence is not a
+joke or an idiom; it is a shorter, more direct sentence with a point of view.
 
 ## Quick test before publishing a sentence
 
@@ -65,6 +126,8 @@ translate, easy to apply, and easy to trust.
 - Would a translator have to _rephrase_ it rather than translate it?
 - Would a capable reader who isn't a programmer feel shut out or talked down to?
 - Does it say anything a shorter sentence wouldn't?
+- Does it sound like a person with an opinion wrote it, or like a manual?
+- Does it exist only to lead into the next sentence?
 
 If any answer is bad, rewrite it.
 

--- a/source/assets/stylesheets/v2.css
+++ b/source/assets/stylesheets/v2.css
@@ -671,6 +671,9 @@
     }
   }
   .content .intro-card {
+    /* A size container so the card's heading can be sized against the card
+       rather than the viewport (see the heading rule below). */
+    container-type: inline-size;
     background: var(--surface);
     border: 1px solid var(--rule);
     border-block-start: 3px solid var(--accent);
@@ -679,12 +682,19 @@
     font-size: var(--step--1);
   }
   .content .intro-card > * + * { margin-block-start: var(--space-xs); }
-  /* Card headings drop the section-separator treatment and sit tighter. */
+  /* Card headings drop the section-separator treatment and sit tighter. They
+     are sized against the card, not the viewport: a viewport-fluid step-1 has
+     no idea how much room the card actually has, so "Who needs this?" wrapped
+     onto two lines whenever three cards had to share a narrower row. 10.5cqi
+     is the widest type that still fits the longest of the three headings on one
+     line, capped at step-1 so wide cards look exactly as before and floored at
+     step-0 so a longer translation wraps rather than shrinking below body text. */
   .content .intro-card :is(h2, h3) {
     margin-block-start: 0;
     padding-block-start: 0;
     border-block-start: 0;
-    font-size: var(--step-1);
+    font-size: clamp(var(--step-0), 10.5cqi, var(--step-1));
+    text-wrap: balance;
   }
 
   /* Top-level headings (##) separate sections; sub-headings (###) just breathe. */
@@ -915,23 +925,16 @@
       overflow: auto;
       margin-block-start: var(--space-2xl);
     }
-    /* Keep the triptych in the reading column only at the low end of the sidebar
-       regime (78-90rem), where a viewport-centered breakout would overlap the
-       TOC. It breaks out again at 90rem (below). */
+    /* Once the TOC occupies the left gutter, the breakout has to stop before it.
+       Narrow the bleed to the widest viewport-centered box whose left edge
+       clears the 15rem sidebar, rather than dropping the triptych back into the
+       reading column: pinning it to the measure made the cards *narrower* at
+       1248-1440px than they were at 1200px, which wrapped the card headings.
+       This reaches the 60rem cap on its own at 90rem, so the row grows
+       continuously across the whole sidebar range. The floor keeps it at least
+       as wide as the reading column it sits in. */
     .content .intro-grid {
-      inline-size: auto;
-      margin-inline: 0;
-    }
-  }
-
-  /* Second breakpoint: once the viewport is wide enough that a centered breakout
-     clears the left TOC (a 60rem breakout needs ~90rem to leave a 15rem gutter),
-     let the triptych break out again even with the sidebar present. This lifts
-     the common 1440-1600px widths, which otherwise waste ~40% of their width. */
-  @media (min-width: 90rem) {
-    .content .intro-grid {
-      inline-size: var(--bleed);
-      margin-inline: var(--bleed-margin);
+      --bleed: max(100%, min(60rem, 100vw - 30rem));
     }
   }
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -54,17 +54,15 @@ People do. Anyone who uses or builds software wants to know what changed, and wh
 - `Fixed` for bug fixes.
 - `Added` for new features.
 
-Changelog sections are listed in order of urgency since readers often skim a changelog to find what affects them. Starting with new features might make it harder to notice security fixes or important removals. Ordering by urgency puts what a reader must act on above what is only good to know.
+We list the types in order of urgency, because readers skim a changelog to find what affects them. Lead with new features and they may miss a security fix or a removal. What a reader must act on goes above what is only good to know.
 
-If you prefer a different order for sections, try to keep it consistent across releases so readers know where to look. Omit any section with no entries instead of cluttering your changelog with empty sections. Within a section, order entries based on what's most useful to readers.
+Prefer a different order? Fine, but keep it consistent across releases so readers know where to look. Leave out empty sections. Within a section, put the entries readers care about most first.
 
-Usually the right type is clear. Three of them cause the most questions:
+Three of the six are easy to confuse:
 
-- `Fixed`: the behavior was wrong, and is now correct.
-- `Changed`: the behavior worked as intended, and now works differently.
-- `Security`: the change addresses a vulnerability. It could fit under Fixed or Changed, but its urgency and audience are different.
-
-When you are unsure, ask whether the old behavior was a bug. If it was, use `Fixed`. If it was intentional and you are changing it, use `Changed`.
+- `Fixed`: the behavior was wrong, and is now correct. A crash on empty input that no longer crashes is `Fixed`.
+- `Changed`: the behavior worked as intended, and now works differently. A default timeout going from 30 to 60 seconds is `Changed`, even if users asked for it.
+- `Security`: the change closes a vulnerability. It could fit under `Fixed` or `Changed`, but readers need to find it fast, and some of those readers are tools, so it gets its own type.
 
 When a `Security` entry has a CVE identifier, lead with it so readers and security tools can match the entry to the advisory:
 
@@ -80,12 +78,11 @@ Some projects also have formal ways they must disclose vulnerabilities (a securi
 There are only six types on purpose. What kind of change it is goes in the type; why it matters goes in the wording of the entry, not in a new type.
 </aside>
 
-An entry like "Rewrote JSON parser; 3x faster on large files" fits better under `Changed` than `Performance`. You can add a category if you genuinely need one, but you rarely will: `Improved` and `New` are often the same as `Changed` and `Added`, and `Internal` or `Housekeeping` changes are rarely notable enough to list at all. Keeping to the six leaves every changelog readable the same way, and parseable by the same tools.
+An entry like "Rewrote JSON parser; 3x faster on large files" belongs under `Changed`, not `Performance`. You can add a type if you truly need one. We have yet to see a case that did: `Improved` and `New` are `Changed` and `Added` with different labels, and `Internal` or `Housekeeping` changes rarely deserve an entry at all. Six types mean every changelog reads the same way, and parses the same way.
 
-Two other type requests are common:
+**Dependencies** are not a type of change. A dependency update can be harmless, a fix, or breaking. If it matters to your users, describe its effect under the right type. If it does not, leave it out.
 
-- **Dependencies** are not a type of change. A dependency update can be harmless, a fix, or breaking. If it matters to your users, describe its effect under the right type. If it does not, leave it out.
-- **Known issues** are discovered, not changed. Note them on the affected version or in your issue tracker. When one is fixed, it goes under `Fixed`.
+**Known issues** are discovered, not changed. Note them on the affected version or in your issue tracker. When one is fixed, it goes under `Fixed`.
 
 ### Breaking changes {#breaking}
 
@@ -101,14 +98,14 @@ A short upgrade note can sit in the entry itself, such as "rename the `color` op
 
 ### Naming the part it touches {#areas}
 
-In a project with distinct parts or features, an entry can specify which was impacted on a change entry:
+In a project with distinct parts or features, an entry can name the part it touches:
 
 ```
 - CLI: `brcat` alias for decoding streams.
 - Parser: recover from a missing final chunk instead of raising.
 ```
 
-Similarly to change types they can group entries by area of focus. They shouldn't be used at at the same heading level as types but there may be situations where multiple changes relate to the same focus area. In that case nesting under a level-4 heading can work:
+Similarly to change types they can group entries by area of focus. They shouldn't be used at the same heading level as types but there may be situations where multiple changes relate to the same focus area. In that case nesting under a level-4 heading can work:
 
 ```
 ### Added
@@ -153,7 +150,7 @@ Making changes and communicating about changes are two different tasks. Curating
 
 ### What should the file be named? {#filename}
 
-Name it `CHANGELOG.md`. Some projects use `HISTORY`, `NEWS`, or `RELEASES`, but a predictable name makes it easy to find. A changelog does not need to list every change. Version control already does that. It lists the notable ones.
+Name it `CHANGELOG.md`. Some projects use `HISTORY`, `NEWS`, or `RELEASES`. The name may feel unimportant, but why make it harder for your users to find what changed? A changelog does not need to list every change; version control already does that. It lists the notable ones.
 
 ### What goes at the top of the file? {#header}
 
@@ -178,27 +175,25 @@ No, although they draw from the same material. A changelog is the complete, ongo
 
 This does not have to mean doing the work twice. At release time, the version's section in the changelog is already the draft: copy it into the release, and expand it only if the announcement wants more. Because every version sits under a predictable `## [x.y.z]` heading, a small script can extract that section and create the release without anyone retyping it.
 
-A host will offer to do this for you. Its release system attaches notes to a tag, notifies watchers, collects build files, and can even generate the notes from merged pull requests or commit messages. But the result lives in the host's database, not your repository. Those notes do not travel with the code, so if you move to another host, they do not come with you. Your changelog does, because it is a file in the repository.
+A host will offer to do this for you. Its release system attaches notes to a tag, notifies watchers, collects build files, and can even generate the notes from merged pull requests or commit messages. That is convenient, and we are not telling you to skip it. But the result lives in the host's database, not your repository. Those notes do not travel with the code, so if you move to another host, they do not come with you. Your changelog does, because it is a file in the repository.
 
 You can treat a generated draft as a starting point, but keep `CHANGELOG.md` as the canonical record and generate host-specific release posts from it. That way you still get the host's reach (notifications, a visible page, attached downloads), and the full history stays in a file you control and can read offline.
 
 ## What makes a changelog worse? {#bad-practices}
 
-A few habits make a changelog less useful.
-
 ### Commit log diffs {#log-diffs}
 
-Do not use a list of commits as a changelog. It is full of noise: merge commits, unclear messages, internal changes. A commit records a step in the source code. A changelog entry records a notable difference, often across several commits, written for the people who use the software.
+Do not paste a list of commits and call it a changelog. It is full of noise: merge commits, unclear messages, internal changes. A commit records a step in the source code. A changelog entry records a notable difference, often across several commits, written for the people who use the software.
 
 > A "git log" is the list of commits in a [git][git] repository. We mention git because it is the most common [version control system][vcs], but this applies to any of them: a raw commit history is not a changelog.
 
 ### Ignoring deprecations {#ignoring-deprecations}
 
-When someone upgrades, it should be clear what will break. Announce a deprecation before you act on it: mark it `Deprecated` in one release, and only `Removed` in a later one, so anyone upgrading meets the warning before the change. Say which version will remove it, so they can plan. If you do nothing else, always record deprecations, removals, and breaking changes.
+When someone upgrades, it should be impossible to miss what will break. Announce a deprecation before you act on it: mark it `Deprecated` in one release, and only `Removed` in a later one, so anyone upgrading meets the warning before the change. Say which version will remove it, so they can plan. If you do nothing else, always record deprecations, removals, and breaking changes.
 
 ### Inconsistent changes {#inconsistent-changes}
 
-A changelog that records only some changes can mislead as much as no changelog. Readers treat it as the full picture. Leave out trivial changes, but include every notable one. A changelog is only trustworthy if it is kept up to date consistently.
+A changelog that records only some changes can mislead as much as no changelog. Readers treat it as the full picture. It should be. Leave out trivial changes, but include every notable one. A changelog is only trustworthy if it is kept up to date consistently.
 
 ## Changelogs, automation, and LLMs {#automation}
 
@@ -228,11 +223,11 @@ A yanked release is a version pulled because of a serious bug or security issue.
 ## [0.0.5] - 2014-12-13 [YANKED]
 ```
 
-The brackets make the tag easy to notice and easy to parse.
+The `[YANKED]` tag is loud on purpose. People need to notice it, and the brackets make it easy to parse too.
 
 ### Should you ever rewrite a changelog? {#rewrite}
 
-You can improve a changelog after a release. A project may forget an entry, or discover a breaking change it did not record. Fixing this is reasonable. When you do, consider noting the date you updated the entry, so readers notice the change.
+Sure. There are always good reasons to improve a changelog. I have opened many pull requests to add missing releases to projects whose changelogs stopped being updated. You may also discover that you forgot to record a breaking change. Fix it, and consider noting the date you updated the entry so readers notice.
 
 ### What if the changelog gets too big? {#large-changelog}
 
@@ -240,9 +235,9 @@ A single file is usually fine, even a long one; many projects keep decades of hi
 
 ### How do I avoid changelog merge conflicts? {#merge-conflicts}
 
-A shared `Unreleased` section is convenient, but it may lead to merge conflicts when branches are frequently merged. While keeping entries short and on the same branch as changes can help, when conflicts are frequent you can tell your version control system to retain conflicting lines with a union merge (e.g. `merge=union` in `.gitattributes` file).
+A shared `Unreleased` section is convenient, but it can cause merge conflicts when branches are merged often. Short entries, committed on the same branch as the change, help. When conflicts stay frequent, tell your version control system to keep both sides with a union merge (`merge=union` in a `.gitattributes` file).
 
-Higher-volume projects can also keep unreleased entries in a separate file inside a directory such as `changelog.d/`. Branches avoid conflict by not editing the same section of the changelog file. At release time the files can be combined into the `CHANGELOG.md` and removed from the subdirectory. This helps with scalability but it does add complexity. It's best to start with a shared `Unreleased` section; add a union merge if conflicts become tedious; and evolve to per-branch files when it becomes unavoidable.
+Higher-volume projects can also keep unreleased entries in a separate file inside a directory such as `changelog.d/`. Branches avoid conflict by not editing the same section of the changelog file. At release time the files can be combined into the `CHANGELOG.md` and removed from the subdirectory. This scales, but it adds complexity. Start with a shared `Unreleased` section. Add a union merge if conflicts become tedious. Move to per-branch files only when nothing else works.
 
 ### What about monorepos? {#monorepos}
 
@@ -260,11 +255,11 @@ The commit history already records who did what, so a changelog does not need to
 
 ### Is there a standard changelog format? {#standard}
 
-Not a formal one. There are older conventions, such as the [GNU changelog style guide][gnu-changelog] and the [GNU NEWS file][gnu-news], but they are limited. Keep a Changelog does not aim to be the one true standard. It aims to show that clear, consistent communication about changes is worth the effort. It started from good practices in open source and applies to any project that needs to communicate its changes.
+Not really. The [GNU changelog style guide][gnu-changelog] and the two-paragraph [GNU NEWS file][gnu-news] guideline exist, and neither is enough. Keep a Changelog does not aim to be the one true standard. It aims to show that clear, consistent communication about changes is worth the effort. It started from good practices in open source and applies to any project that needs to communicate its changes.
 
 ### What does it deliberately leave out? {#scope}
 
-A convention is also defined by what it leaves out. Some common requests are deliberate non-goals:
+A convention is defined by what it leaves out as much as by what it includes. Some common requests are deliberate non-goals:
 
 - No new change types: six are enough.
 - No machine format, schema, or strict layout: this is the format.
@@ -275,11 +270,11 @@ None of this is fixed; it is open to discussion. But additions to a widely used 
 
 ### How can I contribute? {#contribute}
 
-Keep a Changelog is one carefully considered opinion with examples, not the only way to communicate changes. It has helped many projects, and it is still a work in progress. Each version came from discussion in the community. Please [contribute][contribute] or start a [conversation][discussions] if you have ideas or need help.
+This page is not the truth. It is my carefully considered opinion, with examples and information gathered over years, and it is still a work in progress. Every version was shaped by discussion in the community, and I think the discussion matters as much as the result. So please [contribute][contribute], or start a [conversation][discussions] if you have ideas or need help.
 
 ## References {#references}
 
-Keep a Changelog grew from good practices observed in open source, gathered into the convention this page describes, and demonstrated in [its own changelog][kac-changelog]. Olivier Lacan discussed the motivation behind it on [The Changelog podcast][changelog-podcast].
+Keep a Changelog grew from good practices observed in open source, gathered into the convention this page describes, and demonstrated in [its own changelog][kac-changelog]. I went on [The Changelog podcast][changelog-podcast] to talk about why maintainers and contributors should care about changelogs, and about the motivation behind this project.
 
 Since then it has been translated into dozens of languages and adopted by [tens of thousands of open-source projects][adoption-search] whose changelogs note that their format is based on it.
 

--- a/source/en/2.0.0/index.html.md
+++ b/source/en/2.0.0/index.html.md
@@ -1,6 +1,6 @@
 ---
 title: Keep a Changelog
-description: Clearly document the evolution of your projects.
+description: Tell the story of your project's evolution.
 language: en
 version: 2.0.0
 ---

--- a/test/prose_lint_test.rb
+++ b/test/prose_lint_test.rb
@@ -50,6 +50,23 @@ class ProseLintTest < Minitest::Test
     assert_empty findings.select { |f| f.severity == :error }
   end
 
+  def test_machine_flavored_patterns_warn_but_do_not_error
+    hedge = ProseLint.lint("It is recommended that you keep the file in the repository.")
+    assert(hedge.any? { |f| f.rule == "impersonal" && f.severity == :warn })
+
+    buffer = ProseLint.lint("Here are a few ways to think about this.")
+    assert(buffer.any? { |f| f.rule == "buffer" && f.severity == :warn })
+    assert_includes ids("Usually the right type is clear."), "buffer"
+
+    flow = ProseLint.lint("If it was a bug, use `Fixed`. If it was intentional, use `Changed`.")
+    assert(flow.any? { |f| f.rule == "flowchart" && f.severity == :warn })
+
+    # A single conditional is ordinary prose, not a flowchart.
+    assert_empty ProseLint.lint("If it matters to your users, describe its effect.").select { |f| f.rule == "flowchart" }
+    # None of these are build failures on their own.
+    assert_empty errors("It is recommended. Here are a few ways. If a, use b. If c, use d.")
+  end
+
   def test_ignores_code_links_and_suppressed_lines
     # Banned words inside inline code or a URL are not prose.
     assert_empty errors("Use the `--ship` flag.")

--- a/tools/prose_lint.rb
+++ b/tools/prose_lint.rb
@@ -11,7 +11,9 @@
 #           a handful of idioms it calls out by name)
 #   :warn   context-dependent smells worth a human glance but not a build
 #           failure on their own (a bare "just", a very long sentence, several
-#           em-dashes piled into one sentence as bracketed asides)
+#           em-dashes piled into one sentence as bracketed asides, and the
+#           machine-flavored patterns the guide lists: impersonal hedging,
+#           buffer sentences, and if-then flowchart explanations)
 #
 # Scope is the 2.0+ Markdown pages (source/en/*/index.html.md). The older HAML
 # pages keep the earlier, jokier voice on purpose (they are pinned to their era),
@@ -78,7 +80,24 @@ module ProseLint
     { id: "just", severity: :warn, re: /\bjust\b/i,
       hint: "often filler; if it means 'merely', cut it" },
     { id: "call-out", severity: :warn, re: /\bcall(s|ed|ing)? out\b/i,
-      hint: "idiom; prefer 'highlight'" }
+      hint: "idiom; prefer 'highlight'" },
+
+    # --- Machine-flavored prose (guide principles 9-12). These are the tells
+    # the guide names, matched only in their most recognizable forms; the rest
+    # needs a human reader. All warnings: each has legitimate uses. ---
+    { id: "impersonal", severity: :warn, re: /\bit is (recommended|advised|suggested|best practice)\b/i,
+      hint: "impersonal hedging; say who recommends it ('we recommend', 'you can')" },
+    { id: "impersonal", severity: :warn, re: /\bone (may|might|should|can) \b/i,
+      hint: "impersonal 'one'; address the reader as 'you'" },
+    { id: "buffer", severity: :warn,
+      re: /\b(here (are|is)|there are) (a few|some|several|two|three|many) (ways|things|habits|points|options|reasons|cases)\b/i,
+      hint: "buffer sentence; start with the list or the point" },
+    { id: "buffer", severity: :warn, re: /\b(usually|generally|typically|in most cases),? the (right|correct|best) \w+ is (clear|obvious|easy)\b/i,
+      hint: "buffer sentence; delete it or say which cases are hard" },
+    # Two consecutive "If ..., use X." sentences read as a flowchart. Inline code
+    # is scrubbed before matching, so `Fixed` leaves a blank where the name was.
+    { id: "flowchart", severity: :warn, re: /\bIf [^.?!]{1,60}, (use|choose|pick) [^.?!]{0,30}\. If\b/,
+      hint: "flowchart phrasing; give the distinction and a brief example instead" }
   ].freeze
 
   module_function


### PR DESCRIPTION
## Why

The 2.0.0 rewrite fixed real problems (idioms, gatekeeping words, a flat FAQ) but overshot into a sanitized, textbook voice. A voice review of 1.1.0 vs 2.0.0 flagged the tells: transition sentences that say nothing ("Usually the right type is clear. Three of them cause the most questions:"), an if-then procedure for choosing between `Fixed` and `Changed`, and first-person opinion flattened into neutral instruction.

This PR keeps the 2.0.0 structure and every section anchor, and brings the voice back.

## What changed

**Tagline** (second commit): "Clearly document the evolution of your projects." becomes **"Tell the story of your project's evolution."** It drives the hero subtitle, the meta description, and the Open Graph description; the built page was checked for all three. The original 1.1.0 tagline is not restored. Older versions keep it.

**`source/en/2.0.0/index.html.md`** (de-sterilization pass)
- First person and direct address return where the guidance is an opinion: the type-order rationale ("We list the types in order of urgency, because..."), `#rewrite`, `#contribute` ("This page is not the truth. It is my carefully considered opinion..."), and `#references` (the podcast note is first person again instead of third person).
- Buffer sentences deleted: "Usually the right type is clear...", "A few habits make a changelog less useful.", "Two other type requests are common:".
- `Fixed` / `Changed` / `Security` now get a concrete example each instead of "If it was a bug, use Fixed. If it was intentional, use Changed."
- Sentences regain a point of view without regaining idioms: "impossible to miss what will break", "The `[YANKED]` tag is loud on purpose", "why make it harder for your users to find what changed?", "Do not paste a list of commits and call it a changelog."
- Two grammar slips in `#areas` fixed ("at at", "which was impacted on a change entry").

**`docs/tone-and-voice.md`**
- Framing paragraph naming both failure modes: the in-group voice and the sanitized voice.
- Four new principles: opinionated peer not corporate textbook; keep the first person and direct address; no buffer sentences; no algorithmic phrasing.
- New "Tells of machine-written prose" section, new do/don't rows, two new quick-test questions.
- Notes that the old tagline was retired for its idiom, not its opinion, and that the new one is plain and still says what a changelog is for.

**`tools/prose_lint.rb` + `test/prose_lint_test.rb`**
- New warning-level rules (never errors) for the most recognizable forms of those patterns: impersonal hedging ("it is recommended", "one may"), buffer openers ("here are a few ways", "usually the right X is clear"), and back-to-back "If ..., use X. If ..." flowcharts. Tests cover each rule and confirm they stay warnings.

**`CHANGELOG.md`** gets Unreleased `Changed` entries for the tagline and the voice pass. **`docs/2.0.0-changes.md`** records the tagline's two steps and no longer describes the voice as "less first-person".

## Verification

- `bin/rake prose:lint`: clean.
- `bin/rake test`: 88 runs, 332 assertions, 0 failures (includes the full site build).

## Translation impact

No 2.0.0 translations exist yet, so nothing is out of date. When they arrive, translators should translate the new tagline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtFuJxmhAFfPXTnCfjgGpZ